### PR TITLE
Enforce consistent (no) semicolons rule in typescript definitions. Closes #444

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,8 @@
   "rules": {
     "@typescript-eslint/no-unused-vars": ["error", {
       "argsIgnorePattern": "^_"
-    }]
+    }],
+    "@typescript-eslint/member-delimiter-style": "error"
   },
   "ignorePatterns": [
     "assets/",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,9 @@
     "@typescript-eslint/no-unused-vars": ["error", {
       "argsIgnorePattern": "^_"
     }],
-    "@typescript-eslint/member-delimiter-style": "error"
+    "@typescript-eslint/member-delimiter-style": "error",
+    "semi": "off",
+    "@typescript-eslint/semi": ["error", "never"]
   },
   "ignorePatterns": [
     "assets/",

--- a/main/typings.d.ts
+++ b/main/typings.d.ts
@@ -1,5 +1,5 @@
-export type ActivitySource = 'Station' | 'Saturn';
-export type ActivityType = 'info' | 'error';
+export type ActivitySource = 'Station' | 'Saturn'
+export type ActivityType = 'info' | 'error'
 export type TransactionStatus = 'succeeded' | 'processing' | 'failed'
 
 export interface Activity {
@@ -22,12 +22,12 @@ export type FILTransaction = {
 }
 
 // helper
-type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
 // FILTransaction with certain properties changed to optional
 // A processing transaction can have all statuses, because we're briefly showing
 // succeeded and failed ones in the same place as the processing one.
-export type FILTransactionProcessing = PartialBy<FILTransaction, 'hash' | 'height'>;
+export type FILTransactionProcessing = PartialBy<FILTransaction, 'hash' | 'height'>
 
 export interface FoxMessage {
   cid: string;
@@ -43,9 +43,9 @@ export interface FoxMessage {
   };
 }
 
-export type RecordActivityArgs = Omit<Activity, 'id' | 'timestamp'>;
+export type RecordActivityArgs = Omit<Activity, 'id' | 'timestamp'>
 
-export type ModuleJobStatsMap = Record<string, number>;
+export type ModuleJobStatsMap = Record<string, number>
 
 export interface Context {
   recordActivity(activity: RecordActivityArgs): void;

--- a/main/typings.d.ts
+++ b/main/typings.d.ts
@@ -40,7 +40,7 @@ export interface FoxMessage {
   timestamp: number;
   receipt: {
     exitCode: number;
-  }
+  };
 }
 
 export type RecordActivityArgs = Omit<Activity, 'id' | 'timestamp'>;
@@ -54,19 +54,19 @@ export interface Context {
   setModuleJobsCompleted(moduleName: string, count: number): void;
   getTotalJobsCompleted(): number;
 
-  showUI: () => void
-  loadWebUIFromDist: import('electron-serve').loadURL
-  manualCheckForUpdates: () => void,
-  saveSaturnModuleLogAs: () => Promise<void>,
-  confirmChangeWalletAddress: () => boolean,
+  showUI: () => void;
+  loadWebUIFromDist: import('electron-serve').loadURL;
+  manualCheckForUpdates: () => void;
+  saveSaturnModuleLogAs: () => Promise<void>;
+  confirmChangeWalletAddress: () => boolean;
 
-  openReleaseNotes: () => void,
-  restartToUpdate: () => void,
-  getUpdaterStatus: () => {updateAvailable: boolean},
-  browseTransactionTracker: (transactionHash: string) => void,
+  openReleaseNotes: () => void;
+  restartToUpdate: () => void;
+  getUpdaterStatus: () => {updateAvailable: boolean};
+  browseTransactionTracker: (transactionHash: string) => void;
 
-  transactionUpdate: (transactions: (FILTransaction|FILTransactionProcessing)[]) => void,
-  balanceUpdate: (balance:string) => void
+  transactionUpdate: (transactions: (FILTransaction|FILTransactionProcessing)[]) => void;
+  balanceUpdate: (balance:string) => void;
 }
 
 export interface WalletSeed {

--- a/renderer/custom.d.ts
+++ b/renderer/custom.d.ts
@@ -1,5 +1,5 @@
 declare module '*.svg' {
-  import React = require('react');
+  import React = require('react')
   export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>
   const src: string
   export default src

--- a/renderer/src/components/ActivityLog.tsx
+++ b/renderer/src/components/ActivityLog.tsx
@@ -30,7 +30,7 @@ const ActivityLogItem: FC<ActivityEventMessage> = (activity) => {
 }
 
 interface DateSeparatorProps {
-  date: string,
+  date: string;
 }
 
 const DateSeparator: FC<DateSeparatorProps> = ({ date }) => {

--- a/renderer/src/components/FilAddressForm.tsx
+++ b/renderer/src/components/FilAddressForm.tsx
@@ -4,11 +4,11 @@ import { ReactComponent as Warning } from '../assets/img/icons/error.svg'
 import { ReactComponent as EditIcon } from '../assets/img/icons/edit.svg'
 
 interface FilAddressFormProps {
-  destinationAddress: string | undefined,
-  saveDestinationAddress: (address: string | undefined) => void,
-  editMode: boolean,
-  transferMode: boolean,
-  enableEditMode: () => void
+  destinationAddress: string | undefined;
+  saveDestinationAddress: (address: string | undefined) => void;
+  editMode: boolean;
+  transferMode: boolean;
+  enableEditMode: () => void;
 }
 
 const FilAddressForm: FC<FilAddressFormProps> = ({ destinationAddress = '', saveDestinationAddress, editMode, transferMode, enableEditMode }) => {

--- a/renderer/src/components/Modal.tsx
+++ b/renderer/src/components/Modal.tsx
@@ -2,8 +2,8 @@ import { FC } from 'react'
 import WalletModule from '../components/WalletModule'
 
 interface ModalProps {
-  isOpen: boolean
-  setIsOpen: () => void
+  isOpen: boolean;
+  setIsOpen: () => void;
 }
 const Modal : FC<ModalProps> = ({ isOpen, setIsOpen }) => {
   return (

--- a/renderer/src/components/Onboarding.tsx
+++ b/renderer/src/components/Onboarding.tsx
@@ -4,10 +4,10 @@ import { ReactComponent as Page } from './../assets/img/icons/paginator-page.svg
 import { ReactComponent as CurrentPage } from './../assets/img/icons/paginator-current.svg'
 
 interface FooterProps {
-  page: number,
-  pages: number,
-  next: () => void,
-  prev: () => void
+  page: number;
+  pages: number;
+  next: () => void;
+  prev: () => void;
 }
 
 const Footer: FC<FooterProps> = ({ page, pages, next, prev }) => {
@@ -38,7 +38,7 @@ const Footer: FC<FooterProps> = ({ page, pages, next, prev }) => {
 }
 
 interface OnboardingProps {
-  onFinish: () => void
+  onFinish: () => void;
 }
 
 const Onboarding: FC<OnboardingProps> = ({ onFinish }) => {

--- a/renderer/src/components/TransferFunds.tsx
+++ b/renderer/src/components/TransferFunds.tsx
@@ -3,14 +3,14 @@ import { ReactComponent as InfoIcon } from '../assets/img/icons/info.svg'
 import { FilecoinNumber, BigNumber } from '@glif/filecoin-number'
 
 interface TransferFundsButtonsProps {
-  transferMode: boolean,
-  balance: string | undefined,
-  enableTransferMode: () => void,
-  transferAllFunds: () => void,
-  reset: () => void,
-  destinationFilAddress: string | undefined,
-  editMode: boolean,
-  hasCurrentTransaction: boolean
+  transferMode: boolean;
+  balance: string | undefined;
+  enableTransferMode: () => void;
+  transferAllFunds: () => void;
+  reset: () => void;
+  destinationFilAddress: string | undefined;
+  editMode: boolean;
+  hasCurrentTransaction: boolean;
 }
 
 const TransferFundsButtons: FC<TransferFundsButtonsProps> = ({ transferMode, balance, enableTransferMode, transferAllFunds, reset, destinationFilAddress, editMode, hasCurrentTransaction }) => {

--- a/renderer/src/components/WalletModule.tsx
+++ b/renderer/src/components/WalletModule.tsx
@@ -9,7 +9,7 @@ import TransferFundsButtons from './TransferFunds'
 import { ReactComponent as CopyIcon } from '../assets/img/icons/copy.svg'
 
 interface PropsWallet {
-  isOpen: boolean,
+  isOpen: boolean;
 }
 
 const WalletModule: FC<PropsWallet> = ({ isOpen = false }) => {

--- a/renderer/src/components/WalletTransactionStatusWidget.tsx
+++ b/renderer/src/components/WalletTransactionStatusWidget.tsx
@@ -6,8 +6,8 @@ import { FILTransaction, FILTransactionProcessing } from '../typings'
 import { browseTransactionTracker } from '../lib/station-config'
 
 interface WalletTransactionStatusWidgetProps {
-  processingTransaction: FILTransactionProcessing | FILTransaction,
-  renderBackground: boolean
+  processingTransaction: FILTransactionProcessing | FILTransaction;
+  renderBackground: boolean;
 }
 
 const WalletTransactionStatusWidget: FC<WalletTransactionStatusWidgetProps> = ({ processingTransaction, renderBackground = true }) => {

--- a/renderer/src/components/WalletTransactionsHistory.tsx
+++ b/renderer/src/components/WalletTransactionsHistory.tsx
@@ -9,8 +9,8 @@ import { browseTransactionTracker } from '../lib/station-config'
 import WalletOnboarding from './WalletOnboarding'
 
 interface WalletTransactionsHistoryProps {
-  allTransactions: FILTransaction[] | [],
-  processingTransaction: FILTransactionProcessing | undefined
+  allTransactions: FILTransaction[] | [];
+  processingTransaction: FILTransactionProcessing | undefined;
 }
 
 const WalletTransactionsHistory: FC<WalletTransactionsHistoryProps> = ({ allTransactions = [], processingTransaction }) => {
@@ -49,7 +49,7 @@ const WalletTransactionsHistory: FC<WalletTransactionsHistoryProps> = ({ allTran
 }
 
 interface ProcessingTransactionProps {
-  transaction: FILTransactionProcessing | undefined
+  transaction: FILTransactionProcessing | undefined;
 }
 
 const ProcessingTransaction: FC<ProcessingTransactionProps> = ({ transaction }) => {
@@ -94,7 +94,7 @@ const ProcessingTransaction: FC<ProcessingTransactionProps> = ({ transaction }) 
 }
 
 interface TransactionProps {
-  transaction: FILTransaction | undefined
+  transaction: FILTransaction | undefined;
 }
 
 const Transaction: FC<TransactionProps> = ({ transaction }) => {

--- a/renderer/src/components/WalletWidget.tsx
+++ b/renderer/src/components/WalletWidget.tsx
@@ -7,7 +7,7 @@ import WalletTransactionStatusWidget from './WalletTransactionStatusWidget'
 import { FILTransactionProcessing } from '../typings'
 
 interface WalletWidgetProps {
-  onClick: () => void
+  onClick: () => void;
 }
 
 const WalletWidget: FC<WalletWidgetProps> = ({ onClick }) => {

--- a/renderer/src/custom.d.ts
+++ b/renderer/src/custom.d.ts
@@ -1,5 +1,5 @@
 declare module '*.svg' {
-  import React = require('react');
+  import React = require('react')
   export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>
   const src: string
   export default src

--- a/renderer/src/hooks/StationActivity.tsx
+++ b/renderer/src/hooks/StationActivity.tsx
@@ -3,9 +3,9 @@ import { getTotalJobsCompleted, getAllActivities, getTotalEarnings } from '../li
 import { ActivityEventMessage } from '../typings'
 
 interface StationActivity {
-  totalJobs: number,
-  totalEarnings: number,
-  activities: ActivityEventMessage[] | []
+  totalJobs: number;
+  totalEarnings: number;
+  activities: ActivityEventMessage[] | [];
 }
 const useStationActivity = (): StationActivity => {
   const [totalJobs, setTotalJobs] = useState<number>(0)

--- a/renderer/src/hooks/StationWallet.tsx
+++ b/renderer/src/hooks/StationWallet.tsx
@@ -16,14 +16,14 @@ import {
 } from '../typings'
 
 interface Wallet {
-  stationAddress: string,
-  destinationFilAddress: string | undefined,
-  walletBalance: string | undefined,
-  walletTransactions: FILTransaction[] | undefined,
-  editDestinationAddress: (address: string|undefined) => void,
-  processingTransaction: FILTransactionProcessing | undefined,
-  dismissCurrentTransaction: () => void,
-  transferAllFundsToDestinationWallet: () => Promise<void>
+  stationAddress: string;
+  destinationFilAddress: string | undefined;
+  walletBalance: string | undefined;
+  walletTransactions: FILTransaction[] | undefined;
+  editDestinationAddress: (address: string|undefined) => void;
+  processingTransaction: FILTransactionProcessing | undefined;
+  dismissCurrentTransaction: () => void;
+  transferAllFundsToDestinationWallet: () => Promise<void>;
 }
 
 const useWallet = (): Wallet => {
@@ -140,8 +140,8 @@ const useWallet = (): Wallet => {
 }
 
 interface SplitTransactions {
-  processing: FILTransactionProcessing | undefined,
-  confirmed: FILTransaction[]
+  processing: FILTransactionProcessing | undefined;
+  confirmed: FILTransaction[];
 }
 
 const splitWalletTransactions = (transactions: (FILTransaction|FILTransactionProcessing)[]): SplitTransactions => {

--- a/renderer/src/typings.ts
+++ b/renderer/src/typings.ts
@@ -3,71 +3,71 @@ import { Activity } from '../../main/typings'
 declare global {
   interface Window {
     electron: {
-      stationBuildVersion: string,
+      stationBuildVersion: string;
 
-      getAllActivities(): Promise<Activity[]>,
+      getAllActivities(): Promise<Activity[]>;
 
-      getTotalJobsCompleted(): Promise<number>,
-      onJobStatsUpdated (callback: (totalJobCount: number) => void): () => void,
+      getTotalJobsCompleted(): Promise<number>;
+      onJobStatsUpdated (callback: (totalJobCount: number) => void): () => void;
 
-      getUpdaterStatus(): Promise<{updateAvailable: boolean}>,
-      openReleaseNotes(): void,
-      restartToUpdate(): void,
+      getUpdaterStatus(): Promise<{updateAvailable: boolean}>;
+      openReleaseNotes(): void;
+      restartToUpdate(): void;
 
       saturnNode: {
-        start: () => Promise<void>,
-        stop: () => Promise<void>,
-        isRunning: () => Promise<boolean>,
-        isReady: () => Promise<boolean>,
-        getLog: () => Promise<string>,
-        getWebUrl: () => Promise<string>,
-        getFilAddress: () => Promise<string | undefined>,
-        setFilAddress: (address: string | undefined) => Promise<void>
-      },
+        start: () => Promise<void>;
+        stop: () => Promise<void>;
+        isRunning: () => Promise<boolean>;
+        isReady: () => Promise<boolean>;
+        getLog: () => Promise<string>;
+        getWebUrl: () => Promise<string>;
+        getFilAddress: () => Promise<string | undefined>;
+        setFilAddress: (address: string | undefined) => Promise<void>;
+      };
       stationConfig: {
-        getOnboardingCompleted: () => Promise<boolean>,
-        setOnboardingCompleted: () => Promise<void>
-        getStationWalletAddress: () => Promise<string>,
-        getDestinationWalletAddress: () => Promise<string | undefined>,
-        setDestinationWalletAddress: (address: string | undefined) => Promise<void>,
-        getStationWalletBalance: () => Promise<string>,
-        getStationWalletTransactionsHistory: () => Promise<(FILTransaction|FILTransactionProcessing)[]>,
-        transferAllFundsToDestinationWallet: () => Promise<void>,
-        browseTransactionTracker: (transactionHash: string) => void
-      },
+        getOnboardingCompleted: () => Promise<boolean>;
+        setOnboardingCompleted: () => Promise<void>;
+        getStationWalletAddress: () => Promise<string>;
+        getDestinationWalletAddress: () => Promise<string | undefined>;
+        setDestinationWalletAddress: (address: string | undefined) => Promise<void>;
+        getStationWalletBalance: () => Promise<string>;
+        getStationWalletTransactionsHistory: () => Promise<(FILTransaction|FILTransactionProcessing)[]>;
+        transferAllFundsToDestinationWallet: () => Promise<void>;
+        browseTransactionTracker: (transactionHash: string) => void;
+      };
       stationEvents: {
-        onActivityLogged: (callback: (allActivities: Activity[]) => void) => () => void,
-        onJobProcessed: (callback: (value: number) => void) => () => void,
-        onEarningsChanged: (callback: (value: number) => void) => () => void,
-        onUpdateAvailable: (callback: () => void) => () => void,
-        onTransactionUpdate: (callback: (allTransactions: (FILTransaction|FILTransactionProcessing)[]) => void) => () => void,
-        onBalanceUpdate: (callback: (balance: string) => void) => () => void
-      },
+        onActivityLogged: (callback: (allActivities: Activity[]) => void) => () => void;
+        onJobProcessed: (callback: (value: number) => void) => () => void;
+        onEarningsChanged: (callback: (value: number) => void) => () => void;
+        onUpdateAvailable: (callback: () => void) => () => void;
+        onTransactionUpdate: (callback: (allTransactions: (FILTransaction|FILTransactionProcessing)[]) => void) => () => void;
+        onBalanceUpdate: (callback: (balance: string) => void) => () => void;
+      };
       dialogs: {
-        confirmChangeWalletAddress: () => Promise<boolean>
-      }
-    }
+        confirmChangeWalletAddress: () => Promise<boolean>;
+      };
+    };
   }
 }
 
 export type ActivityEventMessage = {
-  id: string
-  timestamp: number
-  type: string
-  source: string
-  message: string
+  id: string;
+  timestamp: number;
+  type: string;
+  source: string;
+  message: string;
 }
 
 export type FILTransactionStatus = 'succeeded' | 'processing' | 'failed'
 
 export type FILTransaction = {
-  hash: string
-  height: number
-  timestamp: number
-  status: FILTransactionStatus
-  outgoing: boolean
-  amount: string
-  address: string
+  hash: string;
+  height: number;
+  timestamp: number;
+  status: FILTransactionStatus;
+  outgoing: boolean;
+  amount: string;
+  address: string;
 }
 
 // helper


### PR DESCRIPTION
Closes #444

- Require semicolons as type member delimiters, as is recommended by Typescript
- Disallow semicolons as line delimiters, as is standard code style