### PR TITLE
telemetry: add periodic `ping`, independent of jobs

### DIFF
--- a/main/job-stats.js
+++ b/main/job-stats.js
@@ -2,7 +2,7 @@
 
 const Store = require('electron-store')
 const { Point } = require('@influxdata/influxdb-client')
-const { writePoint } = require('./telemetry')
+const { writeClient } = require('./telemetry')
 
 /** @typedef {import('./typings').ModuleJobStatsMap} ModuleJobStatsMap */
 
@@ -31,7 +31,7 @@ class JobStats {
     if (moduleName in this.#perModuleJobStats) {
       const diff = count - this.#perModuleJobStats[moduleName]
       if (diff > 0) {
-        writePoint(
+        writeClient.writePoint(
           new Point('jobs-completed')
             .stringField('module', moduleName)
             .intField('value', diff)

--- a/main/telemetry.js
+++ b/main/telemetry.js
@@ -16,7 +16,7 @@ const client = new InfluxDB({
     '0fZyu9zjDvYlaNfOeuwgnQoUI0VcSzeYDpnOLjQyr30mz-Plqels5JHEwgKRbtCcDJbQmv62VnOV_FsZVxgoow=='
 })
 
-export const writeClient = client.getWriteApi(
+const writeClient = client.getWriteApi(
   'Filecoin Station', // org
   'station', // bucket
   'ns' // precision


### PR DESCRIPTION
Previously for every job completed, we were also submitting machine info like wallet hash, operating system, etc. This has two problems:
1. When there are no jobs being completed (eg Saturn testnet traffic problem), we don't know how many Stations there are
2. There is a lot of redundant information submitted.

In this PR I'm introducing a new point `ping`, with all that meta attached, which gets submitted per Station every 10s. This can also be lowered to every 1m if we feel it's too much. In turn, the extra metadata has been removed from `jobs-completed`.

Through this, we can still construct all the queries from our stats dashboard. Some information is lost, but we hadn't used it anyway, like: how many jobs are completed per platform. If we want to add these back, we can do that, but I propose we do it in addition to the periodic `ping`.

If and once this is merged, port to `core`.