### PR TITLE
feat: report arch=arm64 in Rosetta 2

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -59,6 +59,12 @@ log.info('Machine spec: %s version %s', os.type(), os.release())
 // log.info('Machine spec: %s %s version %s', os.type(),
 //   os.machine(),
 //   os.release())
+if (app.runningUnderARM64Translation) {
+  log.warn(
+    'Warning: we are running under ARM64 translation' +
+      ' (macOS Rosetta or Windows WOW).'
+  )
+}
 
 // Expose additional metadata for Electron preload script
 process.env.STATION_BUILD_VERSION = BUILD_VERSION

--- a/main/telemetry.js
+++ b/main/telemetry.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { app } = require('electron')
 const { InfluxDB, Point } = require('@influxdata/influxdb-client')
 const { createHash } = require('node:crypto')
 const { getDestinationWalletAddress } = require('./station-config')
@@ -49,7 +50,12 @@ setInterval(() => {
   point.stringField('version', pkg.version)
   point.tag('station', 'desktop')
   point.tag('platform', platform())
-  point.tag('arch', arch())
+  // `os.arch()` returns `x64` when running in a translated environment on ARM64
+  // machine, e.g. via macOS Rosetta. We don't provide Apple `arm64` builds yet.
+  // As a result, Stations running on Apple Silicon were reporting `x64` arch.
+  // To fix the problem, we detect `arm64` translation and report a different
+  // architecture.
+  point.tag('arch', app.runningUnderARM64Translation ? 'arm64' : arch())
   writeClient.writePoint(point)
 }, 10_000).unref()
 


### PR DESCRIPTION
`os.arch()` returns `x64` when running in a translated environment on ARM64 machine, e.g. via macOS Rosetta. We don't provide Apple `arm64` builds yet.  As a result, Stations running on Apple Silicon were reporting `x64` arch.  To fix the problem, we detect `arm64` translation and report a different architecture.

## Background

I am running Station Desktop version 0.15.3 on an Apple M1 machine. Yet when I look at our Graphana Dashboard, I see that all stations run on (Intel) x64 architecture.

In the electron log file `~/Library/Logs/Filecoin Station/main.log`, I see the following lines:

```
[info]  (main)    Filecoin Station build version: 0.15.3 darwin-x64
[info]  (main)    Machine spec: Darwin version 22.4.0
```

Source code printing these lines:

https://github.com/filecoin-station/desktop/blob/175e1c4b97d4af982efa8b048d588bb4f530e468/main/index.js#L48-L56

It seems that `os.arch()` is returning `x64` even though we are running on `arm64`.

I checked the problem using x64 version of Node.js executed on my arm64 machine:

```
❯ ~/Downloads/node-v18.15.0-darwin-x64/bin/node -e "console.log(os.arch())"
x64
```

Using the arm64 version of Node:

```
❯ node -e "console.log(os.arch())"
arm64
```

This seems to be expected behaviour, see
- https://apple.stackexchange.com/q/427970/51077
- https://stackoverflow.com/q/65346260/69868
- https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment#3616845
