### PR TITLE
fix: better error message & rerender if station wallet is empty string

### DIFF
--- a/main/wallet.js
+++ b/main/wallet.js
@@ -35,6 +35,7 @@ let balance = loadBalance()
  * @param {Context} _ctx
  */
 async function setup (_ctx) {
+  try{
   ctx = _ctx
 
   const { seedIsNew } = await backend.setup()
@@ -45,6 +46,9 @@ async function setup (_ctx) {
   }
 
   log.info('Address: %s', backend.address)
+  }catch(err){
+      throw new Error('Failed to set up the wallet')
+  }
 
   ;(async () => {
     while (true) {

--- a/renderer/src/components/WalletModule.tsx
+++ b/renderer/src/components/WalletModule.tsx
@@ -15,6 +15,7 @@ interface PropsWallet {
 const WalletModule: FC<PropsWallet> = ({ isOpen = false }) => {
   const [editMode, setEditMode] = useState<boolean>(false)
   const [transferMode, setTransferMode] = useState<boolean>(false)
+
   const {
     stationAddress,
     destinationFilAddress,
@@ -23,12 +24,16 @@ const WalletModule: FC<PropsWallet> = ({ isOpen = false }) => {
     editDestinationAddress,
     processingTransaction,
     dismissCurrentTransaction,
+    checkStationAddress,
     transferAllFundsToDestinationWallet
   } = useWallet()
 
   useEffect(() => {
+
     dismissCurrentTransaction()
+    checkStationAddress()
     reset()
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen])
 

--- a/renderer/src/hooks/StationWallet.tsx
+++ b/renderer/src/hooks/StationWallet.tsx
@@ -23,6 +23,7 @@ interface Wallet {
   editDestinationAddress: (address: string|undefined) => void;
   processingTransaction: FILTransactionProcessing | undefined;
   dismissCurrentTransaction: () => void;
+  checkStationAddress: () => void;
   transferAllFundsToDestinationWallet: () => Promise<void>;
 }
 
@@ -72,6 +73,12 @@ const useWallet = (): Wallet => {
   const dismissCurrentTransaction = () => {
     if (processingTransaction && processingTransaction.status !== 'processing') {
       setCurrentTransaction(undefined)
+    }
+  }
+
+  const checkStationAddress = async () => {
+    if(stationAddress === ''){
+      setStationAddress(await getStationWalletAddress())
     }
   }
 
@@ -148,6 +155,7 @@ const useWallet = (): Wallet => {
     editDestinationAddress,
     processingTransaction,
     dismissCurrentTransaction,
+    checkStationAddress,
     transferAllFundsToDestinationWallet
   }
 }


### PR DESCRIPTION
Fixing the issue #609.
- Throws better error message if setting up the wallet fails while starting up.
- update `stationAddress` state if it is empty string.