### PR TITLE
ci: add auto approve dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-      time: "09:00"
+      time: "03:00"
       timezone: "Europe/Berlin"
     commit-message:
       prefix: "deps"

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -15,7 +15,14 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR
-        if: ${{(contains(steps.metadata.outputs.dependency-names, 'eslint') || contains(steps.metadata.outputs.dependency-names, '@types')) && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')}}
+        if: >
+          ${{(
+            contains(steps.metadata.outputs.dependency-names, 'eslint') ||
+            contains(steps.metadata.outputs.dependency-names, '@types')
+          ) && (
+            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+            steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          )}}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -10,9 +10,10 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     strategy:
       matrix:
-        dependency:
+        dependencyStartsWith:
           - eslint
-          - '@types'
+          - '@typescript-eslint/'
+          - '@types/'
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -22,7 +23,7 @@ jobs:
       - name: Approve a PR
         if: >
           ${{(
-            contains(steps.metadata.outputs.dependency-names, matrix.dependency)
+            startsWith(steps.metadata.outputs.dependency-names, matrix.dependencyStartsWith)
           ) && (
             steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
             steps.metadata.outputs.update-type == 'version-update:semver-minor'

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR
-        if: ${{contains(steps.metadata.outputs.dependency-names, 'eslint') && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')}}
+        if: ${{(contains(steps.metadata.outputs.dependency-names, 'eslint') || contains(steps.metadata.outputs.dependency-names, '@types')) && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')}}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        if: ${{contains(steps.metadata.outputs.dependency-names, 'eslint') && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')}}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -8,6 +8,11 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
+    strategy:
+      matrix:
+        dependency:
+          - eslint
+          - '@types'
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -17,8 +22,7 @@ jobs:
       - name: Approve a PR
         if: >
           ${{(
-            contains(steps.metadata.outputs.dependency-names, 'eslint') ||
-            contains(steps.metadata.outputs.dependency-names, '@types')
+            contains(steps.metadata.outputs.dependency-names, matrix.dependency)
           ) && (
             steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
             steps.metadata.outputs.update-type == 'version-update:semver-minor'


### PR DESCRIPTION
For certain packages, there's nothing to do for us as long as tests pass.

The list of package names can be extended in the future to include more safe dependencies.