### PR TITLE
ci: add group dependabot @sentry updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     reviewers:
       - "bajtos"
       - "juliangruber"
+    groups:
+      sentry:
+        patterns:
+          - "@sentry/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/