### PR TITLE
add auto approve patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-approve-minor.yml
+++ b/.github/workflows/dependabot-auto-approve-minor.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-approve minor updates
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    strategy:
+      matrix:
+        dependencyStartsWith:
+          - eslint
+          - '@typescript-eslint/'
+          - '@types/'
+          - '@sentry/'
+          - typescript
+          - '@vitest/ui'
+          - prettier
+          - postcss
+          - vite
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        if: ${{startsWith(steps.metadata.outputs.dependency-names, matrix.dependencyStartsWith) && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')}}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-auto-approve-patch.yml
+++ b/.github/workflows/dependabot-auto-approve-patch.yml
@@ -1,4 +1,4 @@
-name: Dependabot auto-approve
+name: Dependabot auto-approve patch updates
 on: pull_request
 
 permissions:
@@ -11,15 +11,7 @@ jobs:
     strategy:
       matrix:
         dependencyStartsWith:
-          - eslint
-          - '@typescript-eslint/'
-          - '@types/'
-          - '@sentry/'
-          - typescript
-          - '@vitest/ui'
-          - prettier
-          - postcss
-          - vite
+          - react-router-dom
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -27,7 +19,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR
-        if: ${{startsWith(steps.metadata.outputs.dependency-names, matrix.dependencyStartsWith) && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')}}
+        if: ${{startsWith(steps.metadata.outputs.dependency-names, matrix.dependencyStartsWith) && steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
For PRs like https://github.com/filecoin-station/desktop/pull/860. In the react ecosystem it is my experience that you can trust patch updates, but should review minor updates.