### PR TITLE
fix: downgrade Station Core to v14.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@filecoin-station/core": "^14.3.0",
+        "@filecoin-station/core": "^14.2.0",
         "@glif/filecoin-address": "2.0.43",
         "@glif/filecoin-message": "^2.0.44",
         "@glif/filecoin-number": "^2.0.67",
@@ -3359,9 +3359,9 @@
       }
     },
     "node_modules/@filecoin-station/core": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@filecoin-station/core/-/core-14.3.0.tgz",
-      "integrity": "sha512-omp0vMA9sz5gQKhkTD2P3OTurIelxmx+vQBRPmXACrqTuz4PsoGz+oIGGhtaN6c82Lii4glJ5r8lkkTb3w7x+Q==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@filecoin-station/core/-/core-14.2.0.tgz",
+      "integrity": "sha512-upw7YTwYTgY0+yJ1ztd5I//CgRYxsOOPg1KIzj8+856PVA9CGLb5G3tIOFDqhAzsbAp0Q/zdRbTm78Bcu8BcSg==",
       "hasInstallScript": true,
       "dependencies": {
         "@influxdata/influxdb-client": "^1.33.2",
@@ -18961,9 +18961,9 @@
       }
     },
     "@filecoin-station/core": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@filecoin-station/core/-/core-14.3.0.tgz",
-      "integrity": "sha512-omp0vMA9sz5gQKhkTD2P3OTurIelxmx+vQBRPmXACrqTuz4PsoGz+oIGGhtaN6c82Lii4glJ5r8lkkTb3w7x+Q==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@filecoin-station/core/-/core-14.2.0.tgz",
+      "integrity": "sha512-upw7YTwYTgY0+yJ1ztd5I//CgRYxsOOPg1KIzj8+856PVA9CGLb5G3tIOFDqhAzsbAp0Q/zdRbTm78Bcu8BcSg==",
       "requires": {
         "@influxdata/influxdb-client": "^1.33.2",
         "@sentry/node": "^7.41.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/filecoin-station/desktop#readme",
   "dependencies": {
-    "@filecoin-station/core": "^14.3.0",
+    "@filecoin-station/core": "^14.2.0",
     "@glif/filecoin-address": "2.0.43",
     "@glif/filecoin-message": "^2.0.44",
     "@glif/filecoin-number": "^2.0.67",


### PR DESCRIPTION
Revert "feat: upgrade Station Core to v14.3.0 (#1016)"

This reverts commit 5e00d1f32cca40d36d793e415270bd75a029532c.

The version v14.3.0 requires wallet address in the f4/0x format, which we don't support in Desktop yet.
