### PR TITLE
test: verify that Core & Zinnia starts

### DIFF
--- a/test/e2e/app-launch.e2e.test.js
+++ b/test/e2e/app-launch.e2e.test.js
@@ -38,6 +38,9 @@ test.describe.serial('Application launch', async () => {
       timeout: 30000 * TIMEOUT_MULTIPLIER
     })
 
+    electronApp.process().stdout?.pipe(process.stdout)
+    electronApp.process().stderr?.pipe(process.stderr)
+
     // Get the first window that the app opens, wait if necessary.
     mainWindow = await electronApp.firstWindow()
     console.log('WebUI location', await mainWindow.url())

--- a/test/e2e/app-launch.e2e.test.js
+++ b/test/e2e/app-launch.e2e.test.js
@@ -83,4 +83,11 @@ test.describe.serial('Application launch', async () => {
   test('renders Dashboard page', async () => {
     expect(new URL(mainWindow.url()).pathname).toBe('/dashboard')
   })
+
+  test('wait for "Zinnia started." activity log', async () => {
+    await mainWindow.waitForSelector(
+      'div.activity-log p:has-text("Zinnia started.")',
+      { timeout: 1000 * TIMEOUT_MULTIPLIER }
+    )
+  })
 })


### PR DESCRIPTION
- test: forward main process output to console
- test: verify that Core & Zinnia starts

Example test output with the current Core version:

```
  ✓  3 test/e2e/app-launch.e2e.test.js:84:3 › Application launch › renders Dashboard page (4ms)
  ✓  4 test/e2e/app-launch.e2e.test.js:88:3 › Application launch › wait for "Zinnia started." activity log (12ms)
Core exited via signal SIGTERM
Core closed all stdio with code <no code>
Waiting for the debugger to disconnect...
```

Example test output for Core version v14.3.0:

```
Core exited with code: 1
Core closed all stdio with code 1
  ✓  3 test/e2e/app-launch.e2e.test.js:84:3 › Application launch › renders Dashboard page (7ms)
  ✘  4 test/e2e/app-launch.e2e.test.js:88:3 › Application launch › wait for "Zinnia started." activity log (1.0s)
Waiting for the debugger to disconnect...


  1) test/e2e/app-launch.e2e.test.js:88:3 › Application launch › wait for "Zinnia started." activity log

    TimeoutError: page.waitForSelector: Timeout 1000ms exceeded.
    =========================== logs ===========================
    waiting for locator('div.activity-log p:has-text("Zinnia started.")') to be visible
    ============================================================

      87 |
      88 |   test('wait for "Zinnia started." activity log', async () => {
    > 89 |     await mainWindow.waitForSelector(
         |                      ^
      90 |       'div.activity-log p:has-text("Zinnia started.")',
      91 |       { timeout: 1000 * TIMEOUT_MULTIPLIER }
      92 |     )

        at /Users/bajtos/src/filstation/desktop/test/e2e/app-launch.e2e.test.js:89:22

  1 failed
    test/e2e/app-launch.e2e.test.js:88:3 › Application launch › wait for "Zinnia started." activity log
```