### PR TITLE
ci: install package removed in Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      # See https://github.com/nodejs/node-gyp/issues/2869
+      - name: Fix node-gyp and Python
+        run: python3 -m pip install packaging
+
       - name: Cache bigger downloads
         uses: actions/cache@v3
         id: cache
@@ -114,6 +118,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
+
+
+      # See https://github.com/nodejs/node-gyp/issues/2869
+      - name: Fix node-gyp and Python
+        run: python3 -m pip install packaging
 
       - name: Cache bigger downloads
         uses: actions/cache@v3


### PR DESCRIPTION
Links:
- https://github.com/filecoin-station/desktop/issues/1079
- https://github.com/nodejs/node-gyp/issues/2869
