### PR TITLE
fix: formatting of tooltip for scheduled rewards

### DIFF
--- a/renderer/src/pages/Dashboard.tsx
+++ b/renderer/src/pages/Dashboard.tsx
@@ -6,6 +6,12 @@ import UpdateBanner from '../components/UpdateBanner'
 import WalletWidget from '../components/WalletWidget'
 import useStationActivity from '../hooks/StationActivity'
 
+const scheduledRewardsTooltip = `
+This is the reward total you have accrued since your last payout.
+Scheduled earnings will be sent to your Station Wallet approximately
+once a month, provided you have earned more than the payout threshold.
+`.trim().replace(/\r?\n */g, '')
+
 const Dashboard = (): JSX.Element => {
   const { totalJobs, scheduledRewards, activities } = useStationActivity()
   const [walletCurtainIsOpen, setWalletCurtainIsOpen] = useState<boolean>(false)
@@ -42,10 +48,7 @@ const Dashboard = (): JSX.Element => {
               <p className="w-fit text-body-3xs text-grayscale-700 uppercase">Scheduled rewards</p>
               <p
                 className="w-fit text-header-m font-bold font-number total-earnings"
-                title="
-                  This is the reward total you have accrued since your last payout.
-                  Scheduled earnings will be sent to your Station Wallet approximately
-                  once a month, provided you have earned more than the payout threshold."
+                title={scheduledRewardsTooltip}
               >
                 {scheduledRewards}&nbsp;<span className="text-header-3xs">FIL</span>
               </p>

--- a/renderer/src/pages/Dashboard.tsx
+++ b/renderer/src/pages/Dashboard.tsx
@@ -10,7 +10,7 @@ const scheduledRewardsTooltip = `
 This is the reward total you have accrued since your last payout.
 Scheduled earnings will be sent to your Station Wallet approximately
 once a month, provided you have earned more than the payout threshold.
-`.trim().replace(/\r?\n */g, '')
+`.trim().replace(/ *\r?\n */g, ' ')
 
 const Dashboard = (): JSX.Element => {
   const { totalJobs, scheduledRewards, activities } = useStationActivity()


### PR DESCRIPTION
### Before:

<img width="400" alt="Screenshot 2023-11-08 at 10 52 47" src="https://github.com/filecoin-station/desktop/assets/1140553/986be383-b65b-4ec2-90d3-158bb5b55e13">

### After:

<img width="377" alt="Screenshot 2023-11-08 at 11 07 07" src="https://github.com/filecoin-station/desktop/assets/1140553/2fa87c69-4bda-4816-a1ac-bb1ccfb1feaf">
