### PR TITLE
feat: cleaner design of scheduled rewards

### DIFF
--- a/main/wallet.js
+++ b/main/wallet.js
@@ -84,7 +84,15 @@ function getBalance () {
  * @returns {string}
  */
 function getScheduledRewards () {
-  return ethers.utils.formatUnits(scheduledRewards, 18)
+  const fullPrecision = ethers.utils.formatUnits(scheduledRewards, 18 - 3)
+  const [whole, fraction] = fullPrecision.split('.')
+  if (fraction === undefined) return fullPrecision
+  const truncated = fraction
+    // keep the first 4 digits, discard the rest
+    .slice(0, 4)
+    // remove trailing zeroes
+    .replace(/0+$/, '0')
+  return [whole, truncated].join('.')
 }
 
 // Inline `p-debounce.promise` from

--- a/main/wallet.js
+++ b/main/wallet.js
@@ -88,8 +88,8 @@ function getScheduledRewards () {
   const [whole, fraction] = fullPrecision.split('.')
   if (fraction === undefined) return fullPrecision
   const truncated = fraction
-    // keep the first 4 digits, discard the rest
-    .slice(0, 4)
+    // keep the first 6 digits, discard the rest
+    .slice(0, 6)
     // remove trailing zeroes
     .replace(/0+$/, '0')
   return [whole, truncated].join('.')

--- a/main/wallet.js
+++ b/main/wallet.js
@@ -132,7 +132,7 @@ async function _updateScheduledRewards () {
   assert(ctx)
   scheduledRewards = await backend.fetchScheduledRewards()
   walletStore.set('scheduled_rewards', scheduledRewards.toHexString())
-  ctx.scheduledRewardsUpdate(ethers.utils.formatUnits(scheduledRewards, 18))
+  ctx.scheduledRewardsUpdate(getScheduledRewards())
 }
 
 function listTransactions () {

--- a/main/wallet.js
+++ b/main/wallet.js
@@ -84,7 +84,7 @@ function getBalance () {
  * @returns {string}
  */
 function getScheduledRewards () {
-  const fullPrecision = ethers.utils.formatUnits(scheduledRewards, 18 - 3)
+  const fullPrecision = ethers.utils.formatUnits(scheduledRewards, 18)
   const [whole, fraction] = fullPrecision.split('.')
   if (fraction === undefined) return fullPrecision
   const truncated = fraction

--- a/renderer/src/pages/Dashboard.tsx
+++ b/renderer/src/pages/Dashboard.tsx
@@ -50,7 +50,7 @@ const Dashboard = (): JSX.Element => {
                 className="w-fit text-header-m font-bold font-number total-earnings"
                 title={scheduledRewardsTooltip}
               >
-                {scheduledRewards}&nbsp;<span className="text-header-3xs">FIL</span>
+                {scheduledRewards}<span className="text-header-3xs">&nbsp;FIL</span>
               </p>
             </div>
           </div>


### PR DESCRIPTION
- refactor: consistent format of scheduled rewards
- fix: less space between the rewards and the unit
- feat: show only 6 decimal places in rewards

Originally, I wanted to use 3 decimal places. However, the screenshot from @patrickwoodhead showed a number `0.00031...`, which would be rendered as `0.0`. Therefore, we decided to use 6 decimal places instead.

I could not find any helper in ethers.js BigNumber class that would allow me to specify how many decimal places to show. I implemented the truncation myself using string manipulation.

### Before

<img width="654" alt="Screenshot 2023-11-09 at 10 12 21" src="https://github.com/filecoin-station/desktop/assets/1140553/087c06bd-7eb1-475e-9d9a-11e8caec5a16">

### After

<img width="606" alt="Screenshot 2023-11-09 at 10 12 37" src="https://github.com/filecoin-station/desktop/assets/1140553/d74a5967-3ada-4626-9fc7-a22a36574ea6">


