### PR TITLE
test: change wallet for testing scheduled rewards

### DIFF
--- a/main/test/wallet-backend.test.js
+++ b/main/test/wallet-backend.test.js
@@ -2,6 +2,7 @@
 
 const { WalletBackend } = require('../wallet-backend')
 const assert = require('assert').strict
+const { ethers } = require('ethers')
 
 describe('Wallet Backend', function () {
   const backend = new WalletBackend({ disableKeytar: true })
@@ -60,8 +61,7 @@ describe('Wallet Backend', function () {
     it('fetches rewards scheduled for disbursement', async function () {
       await backend.setup(
         // Here we want a random seed that doesn't have any scheduled rewards
-        // eslint-disable-next-line max-len
-        'expect trouble oyster fire leave frown strong mechanic cotton harsh black since bargain paddle stereo fresh neutral math iron coral trophy slab place marine'
+        ethers.Wallet.createRandom().mnemonic.phrase
       )
       const amount = await pRetry(
         () => backend.fetchScheduledRewards(),

--- a/main/test/wallet-backend.test.js
+++ b/main/test/wallet-backend.test.js
@@ -4,6 +4,14 @@ const { WalletBackend } = require('../wallet-backend')
 const assert = require('assert').strict
 const { ethers } = require('ethers')
 
+const randomSeed = () => {
+  const wallet = ethers.Wallet.createRandom()
+  const seed = wallet.mnemonic.phrase
+  console.log('Using randomly-generated wallet address', wallet.address)
+  console.log('SEED:', seed)
+  return seed
+}
+
 describe('Wallet Backend', function () {
   const backend = new WalletBackend({ disableKeytar: true })
   /** @type {import('p-retry').default} */
@@ -59,10 +67,8 @@ describe('Wallet Backend', function () {
 
   describe('fetchScheduledRewards()', function () {
     it('fetches rewards scheduled for disbursement', async function () {
-      await backend.setup(
-        // Here we want a random seed that doesn't have any scheduled rewards
-        ethers.Wallet.createRandom().mnemonic.phrase
-      )
+      // We want a random wallet that doesn't have any scheduled rewards
+      await backend.setup(randomSeed())
       const amount = await pRetry(
         () => backend.fetchScheduledRewards(),
         { retries: 10 }

--- a/main/test/wallet-backend.test.js
+++ b/main/test/wallet-backend.test.js
@@ -3,9 +3,6 @@
 const { WalletBackend } = require('../wallet-backend')
 const assert = require('assert').strict
 
-// eslint-disable-next-line max-len
-const SEED_PHRASE_FOR_TESTS = 'insane believe defy best among myself mistake account paddle episode life music fame impact below define habit rotate clay innocent history depart slice series'
-
 describe('Wallet Backend', function () {
   const backend = new WalletBackend({ disableKeytar: true })
   /** @type {import('p-retry').default} */
@@ -42,7 +39,11 @@ describe('Wallet Backend', function () {
     it('fetches all transactions', /** @this {Mocha.Test} */ async function () {
       this.timeout(20_000)
 
-      await backend.setup(SEED_PHRASE_FOR_TESTS)
+      await backend.setup(
+        // Here we want a seed for a wallet that already has some transactions
+        // eslint-disable-next-line max-len
+        'insane believe defy best among myself mistake account paddle episode life music fame impact below define habit rotate clay innocent history depart slice series'
+      )
       await pRetry(() => backend.fetchAllTransactions(), { retries: 10 })
       assert.notStrictEqual(backend.transactions.length, 0, 'has transactions')
       for (const tx of backend.transactions) {
@@ -57,7 +58,11 @@ describe('Wallet Backend', function () {
 
   describe('fetchScheduledRewards()', function () {
     it('fetches rewards scheduled for disbursement', async function () {
-      await backend.setup(SEED_PHRASE_FOR_TESTS)
+      await backend.setup(
+        // Here we want a random seed that doesn't have any scheduled rewards
+        // eslint-disable-next-line max-len
+        'expect trouble oyster fire leave frown strong mechanic cotton harsh black since bargain paddle stereo fresh neutral math iron coral trophy slab place marine'
+      )
       const amount = await pRetry(
         () => backend.fetchScheduledRewards(),
         { retries: 10 }


### PR DESCRIPTION
The seed used for testing `fetchAllTransactions` is used in other places, too and as a result, the address has some rewards accrued in the contract.

That breaks the test for `fetchScheduledRewards`.

This commit fixes the problem by generating a new random wallet seed for this test.
