### PR TITLE
Fix only show update when it is downloaded. Closes #137

### DIFF
--- a/main/updater.js
+++ b/main/updater.js
@@ -134,28 +134,11 @@ function onUpdateAvailable ({ version /*, releaseNotes */ }) {
   updateAvailable = true
   nextVersion = version
 
-  ipcMain.emit(ipcMainEvents.UPDATE_AVAILABLE)
   log.info(`Update to version ${version} is available, downloading..`)
   autoUpdater.downloadUpdate().then(
     _ => log.info('Update downloaded'),
     err => log.error('Cannot download the update.', err)
   )
-
-  if (!checkingManually) { return }
-  // do not toggle checkingManually off here so we can show a dialog once the
-  // download is finished.
-
-  const buttonIx = showDialogSync({
-    title: 'Update available',
-    message: `A new version ${version} of Filecoin Station is available. ` +
-      'The download will begin shortly in the background.',
-    type: 'info',
-    buttons: ['Close', 'Show Release Notes']
-  })
-
-  if (buttonIx === 1) {
-    openReleaseNotes()
-  }
 }
 
 function openReleaseNotes () {
@@ -207,6 +190,7 @@ function onUpdateDownloaded (ctx, { version /*, releaseNotes */ }) {
     // showUpdateDialog() offers the user to restart
   } else if (ctx.isShowingUI) {
     // show unobtrusive notification + dialog on click
+    ipcMain.emit(ipcMainEvents.UPDATE_AVAILABLE)
     updateNotification = new Notification({
       title: 'Filecoin Station Update',
       body: `An update to Filecoin Station ${version} is available.`

--- a/main/updater.js
+++ b/main/updater.js
@@ -176,9 +176,11 @@ function onUpdateDownloaded (ctx, { version /*, releaseNotes */ }) {
       message: `An update to Filecoin Station ${version} is available. ` +
         'Would you like to install it now?',
       type: 'info',
-      buttons: ['Later', 'Install now']
+      buttons: ['Later', 'Show Release Notes', 'Install now']
     })
-    if (buttonIx === 1) { // install now
+    if (buttonIx === 1) { // show release notes
+      openReleaseNotes()
+    } else if (buttonIx === 2) { // install now
       setImmediate(quitAndInstall)
     }
   }


### PR DESCRIPTION
Closes #137

Instead of showing different update states for when an update is available but not yet downloaded, download progress, and the update is available, this just changes it so that an update notification is shown once an update is downloaded and available. I don't think users care about in-between events, just want to know when they can restart to update.