### PR TITLE
Fix await `ui.loadURL()`. Closes #333

### DIFF
--- a/main/ui.js
+++ b/main/ui.js
@@ -68,7 +68,7 @@ module.exports = async function (ctx) {
     ui.webContents.openDevTools()
 
     console.log('Loading the WebUI')
-    ui.loadURL('http://localhost:3000/')
+    await ui.loadURL('http://localhost:3000/')
   }
 
   // UX trick to avoid jittery UI while browser initializes chrome


### PR DESCRIPTION
Closes #333 

It looks like we mustn't perform any other actions until `loadURL` is finished.

Ref https://github.com/electron/electron/issues/18857#issuecomment-503012296
Ref https://github.com/electron/electron/issues/37123