### PR TITLE
tray: move up "Open Station"

### DIFF
--- a/main/tray.js
+++ b/main/tray.js
@@ -51,6 +51,10 @@ const createContextMenu = (/** @type {Context} */ ctx) => {
       label: `Filecoin Station v${STATION_VERSION}`,
       enabled: false
     },
+    {
+      label: 'Open Station',
+      click: () => ctx.showUI()
+    },
     { type: 'separator' },
     {
       label: `Jobs Completed: ${
@@ -70,11 +74,6 @@ const createContextMenu = (/** @type {Context} */ ctx) => {
         formatTokenValue(ctx.getScheduledRewards())
       } FIL`,
       enabled: false
-    },
-    { type: 'separator' },
-    {
-      label: 'Open Station',
-      click: () => ctx.showUI()
     },
     { type: 'separator' },
     {


### PR DESCRIPTION
This is a more logical placement for me.

Before:

<img width="305" alt="Screenshot 2024-02-08 at 15 47 34" src="https://github.com/filecoin-station/desktop/assets/10247/a0738e09-044a-4ab3-972d-bc75a454ce35">

After:

<img width="307" alt="Screenshot 2024-02-08 at 15 47 16" src="https://github.com/filecoin-station/desktop/assets/10247/2bee023e-1246-4109-8783-172ff706eac4">

I'm happy not to merge this if others disagree