### PR TITLE
ci: disable always failing windows pr builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           USE_HARD_LINKS: false
 
       - name: Show dist/
+        if: ${{ !(matrix.os == 'windows-latest' && github.event_name == 'pull_request') }}
         run: du -sh dist/ && ls -l dist/
 
       # Persist produced binaries and effective config used for building them
@@ -203,6 +204,7 @@ jobs:
       # - action artifacts can be downloaded for 90 days, then are removed by github
       # - binaries in PRs from forks won't be signed
       - name: Attach produced packages to Github Action
+        if: ${{ !(matrix.os == 'windows-latest' && github.event_name == 'pull_request') }}
         uses: actions/upload-artifact@v4
         with:
           name: dist-${{ matrix.os }}
@@ -210,4 +212,5 @@ jobs:
           if-no-files-found: error
 
       - name: Show Cache
+        if: ${{ !(matrix.os == 'windows-latest' && github.event_name == 'pull_request') }}
         run: du -sh ${{ github.workspace }}/.cache/ && ls -l ${{ github.workspace }}/.cache/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,9 @@ jobs:
           DEBUG: electron-builder
 
       - name: Build binaries with electron-builder (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
+        # Windows builds are always failing in PRs. We should fix them, but for
+        # now let's just skip them to remove noise.
+        if: ${{ matrix.os == 'windows-latest' && github.event_name != 'pull_request' }}
         run: |
           npm run build
           npm exec -- electron-builder --publish onTag


### PR DESCRIPTION
Windows builds are always failing in PRs. We should fix them, but for now let's just skip them to remove noise.

I created an issue to remind us to fix the builds: https://github.com/filecoin-station/desktop/issues/1323