### PR TITLE
refactor: rename "logs" to "logLines"

### DIFF
--- a/main/logs.js
+++ b/main/logs.js
@@ -1,16 +1,16 @@
 'use strict'
 
-class Logs {
+class LogLines {
   /**  @type {string[]} */
-  #logs = []
+  #logLines = []
 
   /**
    * Keep last 100 lines of logs for inspection
    * @param {string} line
    */
   push (line) {
-    this.#logs.push(line)
-    this.#logs.splice(0, this.#logs.length - 100)
+    this.#logLines.push(line)
+    this.#logLines.splice(0, this.#logLines.length - 100)
   }
 
   get () {
@@ -22,10 +22,10 @@ class Logs {
    * @returns string
    */
   getLast (n) {
-    return this.#logs.slice(-n).join('\n')
+    return this.#logLines.slice(-n).join('\n')
   }
 }
 
 module.exports = {
-  Logs
+  LogLines
 }


### PR DESCRIPTION
Make it clear in code storing logs that chunks must be split at newlines.

My intention is to prevent regressions like the one fixed by #1319.
