### PR TITLE
refactor: rename `logs.push()` to `logs.pushLine()`

### DIFF
--- a/main/core.js
+++ b/main/core.js
@@ -39,7 +39,7 @@ async function setup (ctx) {
     ctx.showUI()
     const { filePath } = await dialog.showSaveDialog(opts)
     if (filePath) {
-      await fs.writeFile(filePath, logs.get())
+      await fs.writeFile(filePath, logs.getLines())
     }
   }
   await maybeMigrateFiles()
@@ -68,7 +68,7 @@ async function start (ctx) {
   childProcess.stdout
     .pipe(split2())
     .on('data', line => {
-      logs.push(line)
+      logs.pushLine(line)
       let event
       try {
         event = JSON.parse(line)
@@ -115,7 +115,7 @@ async function start (ctx) {
   childProcess.stderr.setEncoding('utf8')
   childProcess.stderr
     .pipe(split2())
-    .on('data', line => logs.push(line))
+    .on('data', line => logs.pushLine(line))
 
   /** @type {string | null} */
   let exitReason = null
@@ -129,7 +129,7 @@ async function start (ctx) {
 
     Sentry.captureException('Core exited', scope => {
       // Sentry UI can't show the full 100 lines
-      scope.setExtra('logs', logs.getLast(10))
+      scope.setExtra('logs', logs.getLastLines(10))
       scope.setExtra('reason', exitReason)
       return scope
     })

--- a/main/core.js
+++ b/main/core.js
@@ -39,7 +39,7 @@ async function setup (ctx) {
     ctx.showUI()
     const { filePath } = await dialog.showSaveDialog(opts)
     if (filePath) {
-      await fs.writeFile(filePath, logs.getLines())
+      await fs.writeFile(filePath, logs.get())
     }
   }
   await maybeMigrateFiles()

--- a/main/logs.js
+++ b/main/logs.js
@@ -13,7 +13,7 @@ class Logs {
     this.#logs.splice(0, this.#logs.length - 100)
   }
 
-  getLines () {
+  get () {
     return this.getLastLines(Infinity)
   }
 

--- a/main/logs.js
+++ b/main/logs.js
@@ -8,20 +8,20 @@ class Logs {
    * Keep last 100 lines of logs for inspection
    * @param {string} line
    */
-  push (line) {
+  pushLine (line) {
     this.#logs.push(line)
     this.#logs.splice(0, this.#logs.length - 100)
   }
 
-  get () {
-    return this.getLast(Infinity)
+  getLines () {
+    return this.getLastLines(Infinity)
   }
 
   /**
    * @param {number} n
    * @returns string
    */
-  getLast (n) {
+  getLastLines (n) {
     return this.#logs.slice(-n).join('\n')
   }
 }


### PR DESCRIPTION
Make it clear in code storing logs that chunks must be split at newlines.

My intention is to prevent regressions like the one fixed by #1319.
