### PR TITLE
logs: increase lines kept to 1000

### DIFF
--- a/main/logs.js
+++ b/main/logs.js
@@ -5,12 +5,12 @@ class Logs {
   #logs = []
 
   /**
-   * Keep last 100 lines of logs for inspection
+   * Keep last 1000 lines of logs for inspection
    * @param {string} line
    */
   pushLine (line) {
     this.#logs.push(line)
-    this.#logs.splice(0, this.#logs.length - 100)
+    this.#logs.splice(0, this.#logs.length - 1000)
   }
 
   get () {


### PR DESCRIPTION
Often 100 lines aren't enough to find the error message, it has already been pushed out of the Array. We can easily keep 1000 lines.

@bajtos or should we raise the limit further? 5k or 10k lines?