### PR TITLE
feat: keep last 1000 log lines from modules

### DIFF
--- a/main/logs.js
+++ b/main/logs.js
@@ -5,12 +5,12 @@ class Logs {
   #logs = []
 
   /**
-   * Keep last 100 lines of logs for inspection
+   * Keep last 1000 lines of logs for inspection
    * @param {string} line
    */
   pushLine (line) {
     this.#logs.push(line)
-    this.#logs.splice(0, this.#logs.length - 100)
+    this.#logs.splice(0, this.#logs.length - 1000)
   }
 
   get () {


### PR DESCRIPTION
Last time I was reviewing Station module logs, I noticed they did not contain any messages from Spark, only messages from Voyager. Both modules produce rather verbose logs, which is good for troubleshooting, but requires us to keep more than 100 log lines.

This commit increases the limit to 1000 lines.

The performance impact should be negligible: assuming 100 bytes/line, the log storage will require ~100KiB of RAM.
