### PR TITLE
Add settings page

### DIFF
--- a/renderer/src/App.css
+++ b/renderer/src/App.css
@@ -37,7 +37,7 @@
   h1, h2, p, a, span,
   .onboarding,
   .activity-item,
-  .modal-bg {
+  .modal-bg, input, label {
     -webkit-app-region: no-drag;
   }
   input {

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -7,7 +7,7 @@ import Plausible from 'src/components/Plausible'
 import { HelmetProvider, Helmet } from 'react-helmet-async'
 import { ROUTES } from 'src/lib/routes'
 import Layout from 'src/components/Layout'
-import Settings from './pages/settings/Settings'
+import Settings from 'src/pages/settings/Settings'
 
 const App = ():JSX.Element => {
   return (

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import Plausible from 'src/components/Plausible'
 import { HelmetProvider, Helmet } from 'react-helmet-async'
 import { ROUTES } from 'src/lib/routes'
 import Layout from 'src/components/Layout'
+import Settings from './pages/settings/Settings'
 
 const App = ():JSX.Element => {
   return (
@@ -25,6 +26,7 @@ const App = ():JSX.Element => {
               <Plausible />
               <Routes>
                 <Route path={ROUTES.dashboard} element={<Dashboard />} />
+                <Route path={ROUTES.settings} element={<Settings />} />
               </Routes>
             </Layout>
             }

--- a/renderer/src/pages/settings/Settings.tsx
+++ b/renderer/src/pages/settings/Settings.tsx
@@ -1,0 +1,20 @@
+const Settings = () => {
+  return (
+    <div className="px-20">
+      <h1 className="font-bold mb-6">Settings</h1>
+      <h2>General</h2>
+      <div className="flex flex-col items-start mb-6">
+        <label>
+          <input type="checkbox" name="startAtLogin"/>
+            Start at login
+        </label>
+        <button type="button">Check for updates</button>
+        <button type="button">Save module logs as...</button>
+      </div>
+      <h2>Security</h2>
+      <button type="button">Export seed phrase</button>
+    </div>
+  )
+}
+
+export default Settings


### PR DESCRIPTION
Add unstlyed settings page, with inputs for initial settings options.
This does not add the settings functionality, that will be done in a follow up PR (https://github.com/filecoin-station/desktop/pull/1498).