### PR TITLE
Add wallet page content

### DIFF
--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import { HelmetProvider, Helmet } from 'react-helmet-async'
 import { ROUTES } from 'src/lib/routes'
 import Layout from 'src/components/Layout'
 import Settings from 'src/pages/settings/Settings'
+import Wallet from 'src/pages/wallet/Wallet'
 import { DialogProvider } from './components/DialogProvider'
 
 const App = ():JSX.Element => {
@@ -28,6 +29,7 @@ const App = ():JSX.Element => {
                     <Plausible />
                       <Routes>
                         <Route path={ROUTES.dashboard} element={<Dashboard />} />
+                        <Route path={ROUTES.wallet} element={<Wallet />} />
                         <Route path={ROUTES.settings} element={<Settings />} />
                       </Routes>
                   </Layout>

--- a/renderer/src/lib/utils.ts
+++ b/renderer/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { BigNumber, FilecoinNumber } from '@glif/filecoin-number'
 import { browseTransactionTracker } from './station-config'
+import { delegatedFromEthAddress, ethAddressFromDelegated, newFromString } from '@glif/filecoin-address'
 
 export function truncateString (value: string, size = 6) {
   return `${value.slice(0, size)}...${value.slice(-size)}`
@@ -13,4 +14,34 @@ export function formatFilValue (value = '') {
 
 export function openExplorerLink (hash?: string) {
   if (hash) browseTransactionTracker(hash)
+}
+
+export async function validateAddress (input: string) {
+  const checkAddressString = async (address: string) => {
+    if (address.startsWith('0x')) {
+      delegatedFromEthAddress(address)
+    } else if (address.startsWith('f4')) {
+      ethAddressFromDelegated(address)
+    } else if (address.startsWith('f1')) {
+      newFromString(address)
+    } else {
+      throw new Error('Invalid address type')
+    }
+    const res = await fetch(`https://station-wallet-screening.fly.dev/${address}`)
+    if (res.status === 403) {
+      throw new Error('Sanctioned address')
+    }
+  }
+
+  try {
+    await checkAddressString(input)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function addressIsF1 (address: string) {
+  return address.startsWith('f1')
 }

--- a/renderer/src/pages/wallet/ConfirmationDialog.tsx
+++ b/renderer/src/pages/wallet/ConfirmationDialog.tsx
@@ -1,0 +1,33 @@
+import { useDialog } from 'src/components/DialogProvider'
+import { formatFilValue, truncateString } from 'src/lib/utils'
+
+const ConfirmationDialog = ({
+  amount,
+  destination,
+  onProceed
+}: {
+  amount: string;
+  destination: string;
+  onProceed: () => void;
+}) => {
+  const { closeDialog } = useDialog()
+
+  function handleProceed () {
+    onProceed()
+    closeDialog()
+  }
+
+  return (
+    <div>
+        <p>Confirm</p>
+        <p>Send {formatFilValue(amount)} FIL to {truncateString(destination)}</p>
+        <div className='my-2 flex gap-4'>
+            <button type='button'onClick={closeDialog}>Cancel</button>
+            <button type='button'onClick={handleProceed}>Transfer</button>
+
+        </div>
+    </div>
+  )
+}
+
+export default ConfirmationDialog

--- a/renderer/src/pages/wallet/TransactionHistory.tsx
+++ b/renderer/src/pages/wallet/TransactionHistory.tsx
@@ -1,0 +1,45 @@
+import dayjs from 'dayjs'
+import { formatFilValue, truncateString } from 'src/lib/utils'
+import { FILTransaction, FILTransactionProcessing } from '../../../../shared/typings'
+
+const TransactionHistory = ({
+  walletTransactions,
+  processingTransaction
+}: {
+  walletTransactions: Array<FILTransaction> | undefined;
+  processingTransaction: FILTransactionProcessing | undefined;
+}) => {
+  return (
+    <div className='flex flex-col gap-2'>
+        <p>Transaction history</p>
+
+        {processingTransaction && (
+            <div className='border'>
+                <div className='flex gap-4'>
+                    <p>{processingTransaction.outgoing
+                      ? `Sending to ${truncateString(processingTransaction.address)}`
+                      : 'Receiving'}
+                    </p>
+                    <p>{formatFilValue(processingTransaction.amount)}FIL</p>
+                </div>
+                <p>{dayjs(processingTransaction.timestamp).format('DD/MM/YYYY')}</p>
+            </div>
+        )}
+
+        {walletTransactions?.map(transaction => (
+            <div key={transaction.hash}>
+                <div className='flex gap-4'>
+                    <p>{transaction.outgoing
+                      ? `Sent to ${truncateString(transaction.address)}`
+                      : 'Received'}
+                    </p>
+                    <p>{formatFilValue(transaction.amount)}FIL</p>
+                </div>
+                <p>{dayjs(transaction.timestamp).format('DD/MM/YYYY')}</p>
+            </div>
+        ))}
+    </div>
+  )
+}
+
+export default TransactionHistory

--- a/renderer/src/pages/wallet/TransferForm.tsx
+++ b/renderer/src/pages/wallet/TransferForm.tsx
@@ -31,9 +31,10 @@ const TransferForm = () => {
   async function handleInputChange (event: ChangeEvent<HTMLInputElement>) {
     if (event.target.value === '') {
       setAddressIsValid(true)
+    } else {
+      setAddressIsValid(await validateAddress(event.target.value))
     }
 
-    setAddressIsValid(await validateAddress(event.target.value))
     setAddress(event.target.value)
   }
 

--- a/renderer/src/pages/wallet/TransferForm.tsx
+++ b/renderer/src/pages/wallet/TransferForm.tsx
@@ -1,0 +1,96 @@
+import { ChangeEvent, FormEvent, useEffect, useRef, useState } from 'react'
+import { useDialog } from 'src/components/DialogProvider'
+import useWallet from 'src/hooks/StationWallet'
+import { validateAddress, addressIsF1 } from 'src/lib/utils'
+import ConfirmationDialog from './ConfirmationDialog'
+
+const TransferForm = () => {
+  const { destinationFilAddress, editDestinationAddress, transferAllFundsToDestinationWallet } = useWallet()
+  const { openDialog } = useDialog()
+  const { walletBalance } = useWallet()
+
+  const [addressIsValid, setAddressIsValid] = useState(true)
+  const [address, setAddress] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (destinationFilAddress) {
+      setAddress(destinationFilAddress)
+    }
+  }, [destinationFilAddress])
+
+  async function handleInputChange (event: ChangeEvent<HTMLInputElement>) {
+    if (event.target.value === '') {
+      setAddressIsValid(true)
+    }
+
+    setAddressIsValid(await validateAddress(event.target.value))
+    setAddress(event.target.value)
+  }
+
+  function handleEditClick () {
+    inputRef.current?.focus()
+  }
+
+  async function handleSaveAddress (event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (addressIsValid) {
+      editDestinationAddress(address)
+    }
+  }
+
+  function handleTransfer (event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    openDialog({
+      content: (
+        <ConfirmationDialog
+          amount={walletBalance || ''}
+          destination={destinationFilAddress || ''}
+          onProceed={transferAllFundsToDestinationWallet}
+        />
+      )
+    })
+  }
+
+  const hasAddressSaved = destinationFilAddress && address === destinationFilAddress
+
+  return (
+    <div>
+        <p className='font-bold'>Transfer Destination address</p>
+
+        <form onSubmit={hasAddressSaved ? handleTransfer : handleSaveAddress}>
+            <div className='my-4'>
+                <input
+                    name='address'
+                    type="text"
+                    placeholder="Destination"
+                    defaultValue={address}
+                    onChange={handleInputChange}
+                    ref={inputRef}
+                />
+            </div>
+
+            {hasAddressSaved && (
+                <button type='button' onClick={handleEditClick} className='block my-2'>Edit</button>
+            )}
+
+            {addressIsValid && addressIsF1(address) && (
+              <p>The FIL address entered is invalid. Please check and try again.</p>
+            )}
+
+            {!addressIsValid && (
+              <p>The FIL address entered is invalid. Please check and try again.</p>
+            )}
+
+            <button type='submit' className='block' disabled={!addressIsValid}>
+                {hasAddressSaved ? 'Transfer' : 'Save'}
+            </button>
+        </form>
+
+    </div>
+  )
+}
+
+export default TransferForm

--- a/renderer/src/pages/wallet/TransferForm.tsx
+++ b/renderer/src/pages/wallet/TransferForm.tsx
@@ -9,6 +9,7 @@ const TransferForm = () => {
   const { openDialog } = useDialog()
   const { walletBalance } = useWallet()
 
+  const [formState, setFormState] = useState<'edit' | 'transfer'>()
   const [addressIsValid, setAddressIsValid] = useState(true)
   const [address, setAddress] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
@@ -16,8 +17,16 @@ const TransferForm = () => {
   useEffect(() => {
     if (destinationFilAddress) {
       setAddress(destinationFilAddress)
+      setFormState('transfer')
     }
   }, [destinationFilAddress])
+
+  useEffect(() => {
+    if (formState === 'edit') {
+      inputRef.current?.focus()
+      inputRef.current?.setSelectionRange(0, inputRef.current.value.length)
+    }
+  }, [formState])
 
   async function handleInputChange (event: ChangeEvent<HTMLInputElement>) {
     if (event.target.value === '') {
@@ -29,7 +38,7 @@ const TransferForm = () => {
   }
 
   function handleEditClick () {
-    inputRef.current?.focus()
+    setFormState('edit')
   }
 
   async function handleSaveAddress (event: FormEvent<HTMLFormElement>) {
@@ -37,6 +46,7 @@ const TransferForm = () => {
 
     if (addressIsValid) {
       editDestinationAddress(address)
+      setFormState('transfer')
     }
   }
 
@@ -54,7 +64,8 @@ const TransferForm = () => {
     })
   }
 
-  const hasAddressSaved = destinationFilAddress && address === destinationFilAddress
+  const hasAddressSaved = destinationFilAddress && formState === 'transfer'
+  const hasBalance = Number(walletBalance) >= 0.01
 
   return (
     <div>
@@ -64,11 +75,13 @@ const TransferForm = () => {
             <div className='my-4'>
                 <input
                     name='address'
+                    className='border-b p-2'
                     type="text"
                     placeholder="Destination"
                     defaultValue={address}
                     onChange={handleInputChange}
                     ref={inputRef}
+                    disabled={formState !== 'edit'}
                 />
             </div>
 
@@ -84,9 +97,25 @@ const TransferForm = () => {
               <p>The FIL address entered is invalid. Please check and try again.</p>
             )}
 
-            <button type='submit' className='block' disabled={!addressIsValid}>
-                {hasAddressSaved ? 'Transfer' : 'Save'}
-            </button>
+            {hasAddressSaved
+              ? (
+              <button
+                type='submit'
+                className='block disabled:opacity-30'
+                disabled={!addressIsValid || !hasBalance}
+              >
+                Transfer
+              </button>
+                )
+              : (
+              <button
+                type='submit'
+                className='block disabled:opacity-30'
+                disabled={!addressIsValid}
+              >
+                Save
+              </button>
+                )}
         </form>
 
     </div>

--- a/renderer/src/pages/wallet/Wallet.tsx
+++ b/renderer/src/pages/wallet/Wallet.tsx
@@ -1,0 +1,50 @@
+import useWallet from 'src/hooks/StationWallet'
+import { formatFilValue, openExplorerLink, truncateString } from 'src/lib/utils'
+import TransactionHistory from './TransactionHistory'
+import TransferForm from './TransferForm'
+
+const Wallet = () => {
+  const {
+    walletBalance,
+    stationAddress,
+    stationAddress0x,
+    walletTransactions,
+    processingTransaction
+  } = useWallet()
+
+  return (
+    <div>
+        <h1 className='font-bold mb-4'>Wallet</h1>
+        <div className="flex gap-8">
+            <section className="w-1/3">
+                <div className='mb-4'>
+                    <h2>Station wallet balance</h2>
+                    {formatFilValue(walletBalance)}{' '}FIL
+                </div>
+                <div className='flex justify-between'>
+                    <p>Station address</p>
+                    <button type='button' onClick={() => openExplorerLink(stationAddress)}>Explorer</button>
+                </div>
+                <div className='flex justify-between'>
+                    <span>{truncateString(stationAddress)}</span>
+                    <span>{truncateString(stationAddress0x)}</span>
+                </div>
+
+                <div className='my-4'>
+                    <TransactionHistory
+                        walletTransactions={walletTransactions}
+                        processingTransaction={processingTransaction}
+                    />
+                </div>
+            </section>
+
+            <section className="w-1/3">
+                <TransferForm />
+            </section>
+
+        </div>
+    </div>
+  )
+}
+
+export default Wallet


### PR DESCRIPTION
Add unstyled content to Wallet page:
 - Station address and balance info
 - Tx history and currently processing tx.
 - FIL transfer form (adapted from the current form). This allows updating the destination address and requesting the transfer, includes validation.
 - Requesting the transfer opens a confirmation modal; on confirm it calls the `transferAllFundsToDestinationWallet` function.