### PR TITLE
deps: bump @filecoin-station/core from 20.5.1 to 20.5.2 (#1536)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@filecoin-station/core": "^20.5.1",
+        "@filecoin-station/core": "^20.5.2",
         "@glif/filecoin-address": "3.0.5",
         "@glif/filecoin-message": "^3.0.5",
         "@glif/filecoin-number": "^3.0.3",
@@ -3301,9 +3301,9 @@
       }
     },
     "node_modules/@filecoin-station/core": {
-      "version": "20.5.1",
-      "resolved": "https://registry.npmjs.org/@filecoin-station/core/-/core-20.5.1.tgz",
-      "integrity": "sha512-3USiR4MpXudTIGjLAcjW0Abpluoyg8VvCilGnWDxc5B5PSladUDStFLqFnqX1FiTkkYrkJ/rUIgZ9qCa6OtgWQ==",
+      "version": "20.5.2",
+      "resolved": "https://registry.npmjs.org/@filecoin-station/core/-/core-20.5.2.tgz",
+      "integrity": "sha512-EL1LkSMW9yf1EioMLVPjIzCu0m4RNQWMjUfydHpKC6vBrmOM3HtZJIZaasMhFoQJNbcZihrqxNkBpHSOMgJh7Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@glif/filecoin-address": "^3.0.0",
@@ -23213,9 +23213,9 @@
       }
     },
     "@filecoin-station/core": {
-      "version": "20.5.1",
-      "resolved": "https://registry.npmjs.org/@filecoin-station/core/-/core-20.5.1.tgz",
-      "integrity": "sha512-3USiR4MpXudTIGjLAcjW0Abpluoyg8VvCilGnWDxc5B5PSladUDStFLqFnqX1FiTkkYrkJ/rUIgZ9qCa6OtgWQ==",
+      "version": "20.5.2",
+      "resolved": "https://registry.npmjs.org/@filecoin-station/core/-/core-20.5.2.tgz",
+      "integrity": "sha512-EL1LkSMW9yf1EioMLVPjIzCu0m4RNQWMjUfydHpKC6vBrmOM3HtZJIZaasMhFoQJNbcZihrqxNkBpHSOMgJh7Q==",
       "requires": {
         "@glif/filecoin-address": "^3.0.0",
         "@influxdata/influxdb-client": "^1.33.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/filecoin-station/desktop#readme",
   "dependencies": {
-    "@filecoin-station/core": "^20.5.1",
+    "@filecoin-station/core": "^20.5.2",
     "@glif/filecoin-address": "3.0.5",
     "@glif/filecoin-message": "^3.0.5",
     "@glif/filecoin-number": "^3.0.3",


### PR DESCRIPTION
Bump [@filecoin-station/core](https://github.com/filecoin-station/core) from 20.5.1 to 20.5.2.
- [Release notes](https://github.com/filecoin-station/core/releases)
- [Commits](https://github.com/filecoin-station/core/compare/v20.5.1...v20.5.2)
