### PR TITLE
Fix indent more code consistently

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,9 +20,8 @@
       "code": 115,
       "ignoreUrls": true
     }],
-    "indent": ["error", 2, {
-      "SwitchCase": 1
-    }]
+    "indent": "off",
+    "@typescript-eslint/indent": ["error", 2]
   },
   "ignorePatterns": [
     "assets/",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,9 @@
     "max-len": ["error", {
       "code": 115,
       "ignoreUrls": true
+    }],
+    "indent": ["error", 2, {
+      "SwitchCase": 1
     }]
   },
   "ignorePatterns": [
@@ -72,8 +75,7 @@
         "react/jsx-first-prop-new-line": "error",
         "react/jsx-max-props-per-line": ["error", { "maximum": 1, "when": "multiline" }],
         "react/jsx-indent-props": ["error", "first"],
-        "react/jsx-closing-bracket-location": "error",
-        "indent": ["error", 2]
+        "react/jsx-closing-bracket-location": "error"
       }
     }
   ]

--- a/renderer/src/typings.ts
+++ b/renderer/src/typings.ts
@@ -35,7 +35,7 @@ declare global {
         onEarningsChanged: (callback: (value: number) => void) => () => void;
         onReadyToUpdate: (callback: () => void) => () => void;
         onTransactionUpdate:
-          (callback: (allTransactions: (FILTransaction|FILTransactionProcessing)[]) => void) => () => void;
+        (callback: (allTransactions: (FILTransaction|FILTransactionProcessing)[]) => void) => () => void;
         onBalanceUpdate: (callback: (balance: string) => void) => () => void;
         onScheduledRewardsUpdate: (callback: (balance: string) => void) => () => void;
       };


### PR DESCRIPTION
- fix the `indent` rule only applied to `renderer/` code
- type definitions weren't linted, this was ignored:
```ts
type foo = {
  bar: string;
       beep: string;
}
```
I noticed this seeing 4 spaces in https://github.com/filecoin-station/desktop/pull/1577/files#diff-d616452d0c127e14d1d82d22f58614e487a7d94e48fe57a165b528f8cc8c3581.

@bajtos merging now in order to update the v2 branch and not block Lange on it. Hindsight please 🙏 
