### PR TITLE
General fixes

### DIFF
--- a/renderer/src/components/Button.tsx
+++ b/renderer/src/components/Button.tsx
@@ -28,7 +28,7 @@ const Button = <C extends ElementType = typeof DEFAULT_ELEMENT>({
   const Component = as || DEFAULT_ELEMENT
 
   const className = classNames(
-    `flex gap-2 items-center font-mono text-2xs rounded-[28px] 
+    `flex gap-2 items-center font-mono text-mono-2xs rounded-[28px] 
      focus:ring ring-slate-400 focus:outline-0 disabled:cursor-not-allowed`,
     variantClassNames[variant],
     props.className

--- a/renderer/src/components/DialogProvider.tsx
+++ b/renderer/src/components/DialogProvider.tsx
@@ -37,10 +37,10 @@ export const DialogProvider = ({ children }: {children: ReactNode}) => {
 
       <Root open={isOpen} onOpenChange={setIsOpen}>
         <Portal>
-          <Overlay className='fixed inset-0 bg-[#00000055] backdrop-blur' data-dialog-overlay />
+          <Overlay className='fixed inset-0 bg-[#00000055] backdrop-blur animate-fadeIn' data-dialog-overlay />
           <Content
             className='fixed top-[50%] left-[50%] max-h-[85vh] w-[90vw] max-w-[450px]
-                translate-x-[-50%] translate-y-[-50%] z-10'
+                translate-x-[-50%] translate-y-[-50%] z-10 animate-fadeIn'
           >
             {content}
           </Content>

--- a/renderer/src/components/Sidebar.tsx
+++ b/renderer/src/components/Sidebar.tsx
@@ -7,6 +7,8 @@ import WalletIcon from 'src/assets/img/icons/wallet.svg?react'
 import SettingsIcon from 'src/assets/img/icons/settings.svg?react'
 import MenuArrow from 'src/assets/img/icons/menu-arrow.svg?react'
 import Logo from 'src/assets/img/icons/logo-symbol.svg?react'
+import classNames from 'classnames'
+import Transition from './Transition'
 
 const links = [
   {
@@ -35,7 +37,11 @@ const Sidebar = () => {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <section className='sticky top-0 group pt-9 bg-slate-50 outline-slate-400 outline-dashed outline-1'>
+    <section className={classNames(
+      'sticky top-0 group pt-9 bg-slate-50 outline-slate-400 outline-dashed outline-1 transition-all',
+      isOpen ? 'w-[142px]' : 'w-[80px]'
+    )}
+    >
       <div className='flex flex-col items-center gap-9 px-4 pt-5'>
         <Logo />
 
@@ -45,23 +51,35 @@ const Sidebar = () => {
           className='nav-button absolute right-0 top-16 translate-x-[50%] outline-slate-400
           opacity-0 group-hover:opacity-100 focus:opacity-100'
         >
-          <div className={`text-primary ${isOpen ? 'rotate-180' : ''}`}>
+          <div className={classNames('text-primary', {
+            'rotate-180': isOpen
+          })}
+          >
             <MenuArrow />
           </div>
         </button>
 
-        <nav className='flex flex-col gap-2'>
+        <nav className='flex flex-col gap-2 w-full'>
           {links.map(({ href, title, Icon }) => (
             <NavLink
               to={href}
               key={href}
-              className={({ isActive }) =>
-                `flex gap-2 items-center py-3.5 nav-button 
-                  ${isOpen ? 'px-3' : 'px-3.5'} 
-                  ${isActive ? 'active' : ''}`}
+              className={({ isActive }) => classNames(
+                'flex gap-2 items-center py-3.5 px-3.5 nav-button',
+                { active: isActive }
+              )}
             >
-              <Icon />
-              <span className={`uppercase text-body-3xs ${isOpen ? 'block' : 'hidden'}`}>{title}</span>
+              <div className='w-5'>
+                <Icon />
+              </div>
+              <Transition
+                as='span'
+                on={isOpen}
+                delayIn={100}
+                className='uppercase text-body-3xs'
+              >
+                {title}
+              </Transition>
             </NavLink>
           ))}
         </nav>

--- a/renderer/src/components/WalletWidget.tsx
+++ b/renderer/src/components/WalletWidget.tsx
@@ -24,13 +24,13 @@ const WalletWidget = () => {
   }
 
   return (
-    <div className='absolute top-5 right-9 flex gap-5 no-drag-area'>
+    <div className='absolute top-5 right-9 flex gap-5'>
       <TransactionStatusIndicator transaction={processingTransaction} />
       <button
         data-testid='wallet-widget'
         type='button'
         onClick={handleClick}
-        className={`flex items-center gap-3 text-black 
+        className={`flex items-center gap-3 text-black no-drag-area
         focus-visible:outline-slate-400 focus:outline-slate-400 p-1`}
       >
         <WalletIcon />

--- a/renderer/src/components/WalletWidget.tsx
+++ b/renderer/src/components/WalletWidget.tsx
@@ -30,7 +30,7 @@ const WalletWidget = () => {
         data-testid='wallet-widget'
         type='button'
         onClick={handleClick}
-        className={`flex items-center gap-3 text-black no-drag-area
+        className={`flex items-center gap-3 text-black no-drag-area z-10
         focus-visible:outline-slate-400 focus:outline-slate-400 p-1`}
       >
         <WalletIcon />

--- a/renderer/src/lib/grid.ts
+++ b/renderer/src/lib/grid.ts
@@ -62,7 +62,7 @@ export class Grid {
     this.warp.x = this.percent(50, 'x')
     this.warp.y = this.percent(70, 'y')
     this.midLine.x = this.percent(50, 'x')
-    this.midLine.y = this.percent(70, 'y')
+    this.midLine.y = this.percent(10, 'y')
   }
 
   updateWarp (config: Record<string, number>) {
@@ -279,6 +279,7 @@ export class Grid {
     duration: number;
     delay?: number;
   }) {
+    this.midLine.y = this.warp.y
     const args = {
       forceDiff: targetForce - this.force,
       midLineYDiff: this.midLine.y - (this.target.y + 20),

--- a/renderer/src/lib/grid.ts
+++ b/renderer/src/lib/grid.ts
@@ -257,6 +257,17 @@ export class Grid {
     }
   }
 
+  clear () {
+    this.ctx.clearRect(0, 0, this.width, this.height)
+  }
+
+  renderAll () {
+    this.clear()
+    this.renderGrid()
+    this.renderTargetCircles()
+    this.renderMidLine()
+  }
+
   // Transition between 2 states, transitioning the force value
   // and revealing the midLine
   tweenRender ({
@@ -277,7 +288,7 @@ export class Grid {
     }
 
     if (delay) {
-      this.renderGrid()
+      this.renderAll()
       setTimeout(() => {
         this.tweenRenderFrame(args)
       }, delay)
@@ -308,10 +319,7 @@ export class Grid {
 
     args.frame++
 
-    this.ctx.clearRect(0, 0, this.width, this.height)
-    this.renderTargetCircles()
-    this.renderMidLine()
-    this.renderGrid()
+    this.renderAll()
 
     requestAnimationFrame(() => this.tweenRenderFrame(args))
   }

--- a/renderer/src/pages/dashboard/ActivityInfo.tsx
+++ b/renderer/src/pages/dashboard/ActivityInfo.tsx
@@ -45,14 +45,15 @@ const ActivityInfo = () => {
         </Text>
         <Text font='mono' size='s'>{totalJobs.toLocaleString()}</Text>
       </BorderedBox>
-      <div className='h-full max-h-[68vh] flex flex-col'>
+      <div className='h-full flex flex-col relative'>
         <BorderedBox className='py-4 px-5' isGrouped>
           <Text as='h3' font='mono' size='3xs' color='primary' uppercase>
               &#47;&#47; Activity ... :
           </Text>
         </BorderedBox>
         <BorderedBox
-          className='p-5 h-full overflow-y-scroll custom-scrollbar flex-1 max-h-full activity-log'
+          className='p-5 h-full overflow-y-scroll custom-scrollbar flex-1 max-h-[calc(100%_-_50px)]
+          bottom-0 activity-log absolute'
           isGrouped
         >
           {Object.entries(activitiesByDate).map(([date, log]) => (

--- a/renderer/src/pages/dashboard/Dashboard.tsx
+++ b/renderer/src/pages/dashboard/Dashboard.tsx
@@ -8,9 +8,7 @@ const Dashboard = (): JSX.Element => {
   const { historicalRewards, totalRewardsReceived, scheduledRewards } = useStationRewards()
 
   return (
-    <main
-      className='gap-5 px-9 mt-28 flex-1  grid grid-rows-[auto_1fr] grid-cols-[1fr_217px] pb-6'
-    >
+    <main className='gap-5 px-9 mt-28 flex-1  grid grid-rows-[auto_1fr] grid-cols-[1fr_217px] pb-6 animate-fadeIn'>
       <BorderedBox className='flex-1 row-span-2 flex flex-col'>
         <RewardsInfo totalRewardsReceived={totalRewardsReceived} scheduledRewards={scheduledRewards} />
         <ChartController historicalRewards={historicalRewards} />

--- a/renderer/src/pages/modules/ModuleCard.tsx
+++ b/renderer/src/pages/modules/ModuleCard.tsx
@@ -37,7 +37,7 @@ const moduleStatus = {
 
 const ModuleCard = ({ module }: {module: Module}) => {
   return (
-    <div className='bg-slate-50 border border-dashed border-slate-400 rounded-xl'>
+    <div className='bg-slate-50 border border-dashed border-slate-400 rounded-xl animate-fadeIn'>
       <div className='h-[276px] flex border-b border-dashed border-slate-400'>
         <div className='py-9 px-5 flex flex-col gap-3 justify-between'>
           <Text as='h2' size="l" font='mono'>{module.name}</Text>
@@ -49,7 +49,8 @@ const ModuleCard = ({ module }: {module: Module}) => {
           </div>
         </div>
         <figure
-          className='flex w-[140px] py-9 px-5 border-l border-dashed border-slate-400 bg-white rounded-tr-xl'
+          className='flex w-[140px] shrink-0 py-9 px-5 border-l border-dashed border-slate-400 bg-white
+          rounded-tr-xl'
         >
           <img src={module.logo} alt={`${module.name}'s logo`} className='max-w-[100px] m-auto' />
         </figure>

--- a/renderer/src/pages/settings/Settings.tsx
+++ b/renderer/src/pages/settings/Settings.tsx
@@ -15,7 +15,7 @@ import SaveIcon from 'src/assets/img/icons/save.svg?react'
 import ExportIcon from 'src/assets/img/icons/export.svg?react'
 
 const Settings = () => {
-  const [isOpenAtLoginChecked, setIsOpenAtLoginChecked] = useState(true)
+  const [isOpenAtLoginChecked, setIsOpenAtLoginChecked] = useState<boolean>()
 
   const updateIsOpenAtLogin = async () => setIsOpenAtLoginChecked(await isOpenAtLogin())
 
@@ -38,6 +38,7 @@ const Settings = () => {
           <SettingsGroupItem
             title='Start at login'
             input={
+              isOpenAtLoginChecked !== undefined &&
               <SwitchInput
                 name="openAtLogin"
                 onChange={handleClick}

--- a/renderer/src/pages/settings/Settings.tsx
+++ b/renderer/src/pages/settings/Settings.tsx
@@ -33,7 +33,7 @@ const Settings = () => {
       <header className='mb-9'>
         <Text as='h1' font='mono' size='xs' color='primary' uppercase>&#47;&#47; Settings ... :</Text>
       </header>
-      <div className='flex flex-col gap-7'>
+      <div className='flex flex-col gap-7 animate-fadeIn'>
         <SettingsGroup name='General'>
           <SettingsGroupItem
             title='Start at login'

--- a/renderer/src/pages/wallet/BalanceControl.tsx
+++ b/renderer/src/pages/wallet/BalanceControl.tsx
@@ -1,6 +1,6 @@
 import Button from 'src/components/Button'
 import Text from 'src/components/Text'
-import { formatFilValue } from 'src/lib/utils'
+import { formatFilValue, truncateString } from 'src/lib/utils'
 import { Wallet } from 'src/hooks/StationWallet'
 import Tooltip from 'src/components/Tooltip'
 import { ReactNode, useState } from 'react'
@@ -29,11 +29,13 @@ const BalanceControl = ({
   walletBalance = '',
   sendThreshold,
   processingTransaction,
+  destinationFilAddress,
   transferAllFundsToDestinationWallet
 }: {
   walletBalance?: string;
   sendThreshold: number;
   processingTransaction: Wallet['processingTransaction'];
+  destinationFilAddress: Wallet['destinationFilAddress'];
   transferAllFundsToDestinationWallet: Wallet['transferAllFundsToDestinationWallet'];
 }) => {
   const [isShowingConfirm, setIsShowingConfirm] = useState(false)
@@ -54,7 +56,8 @@ const BalanceControl = ({
           className='flex flex-col gap-5 text-center m-auto'
         >
           <Text as="p" size='s'>
-                Send <strong>{formatFilValue(walletBalance)}</strong> to the destination address?
+              Send <strong>{formatFilValue(walletBalance)} FIL</strong> to {' '}
+            <strong>{truncateString(destinationFilAddress || '')}</strong>?
           </Text>
           <div className='flex gap-5 justify-center'>
             <Button

--- a/renderer/src/pages/wallet/DestinationAddressForm.tsx
+++ b/renderer/src/pages/wallet/DestinationAddressForm.tsx
@@ -14,7 +14,9 @@ const DestinationAddressForm = ({
 }) => {
   const { inputRef, validateOnChange, inputState } = useAddressValidation({ initialValid: false })
 
-  function handleSubmit () {
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+
     if (inputRef.current) {
       onSave(inputRef.current.value)
     }
@@ -24,6 +26,8 @@ const DestinationAddressForm = ({
 
   return (
     <Transition
+      as='form'
+      onSubmit={handleSubmit}
       on={!hasAddressSaved}
       outClass='bg-black scale-95 p-[1px] border-0'
       inClass='bg-white max-h-[208px] border-slate-400 p-5'
@@ -59,7 +63,7 @@ const DestinationAddressForm = ({
           variant='primary'
           className='w-fit m-auto'
           disabled={!inputState.isValid}
-          onClick={handleSubmit}
+          type='submit'
         >
           Save
         </Button>

--- a/renderer/src/pages/wallet/EditDestinationAddressForm.tsx
+++ b/renderer/src/pages/wallet/EditDestinationAddressForm.tsx
@@ -19,10 +19,19 @@ const EditDestinationAddressForm = ({
   const [showTooltip, setShowTooltip] = useState(false)
   const { inputRef, validateOnChange, inputState } = useAddressValidation({ initialValid: true })
 
-  const handleSave = () => {
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+
+    if (!editing) {
+      setEditing(true)
+
+      return
+    }
+
     editDestinationAddress(inputRef.current?.value)
     setEditing(false)
     setShowTooltip(true)
+    inputRef.current?.blur()
 
     const timeout = setTimeout(() => {
       setShowTooltip(false)
@@ -34,16 +43,15 @@ const EditDestinationAddressForm = ({
   useEffect(() => {
     if (editing) {
       inputRef.current?.focus()
-      inputRef.current?.setSelectionRange(0, inputRef.current.value.length)
+      inputRef.current?.setSelectionRange(inputRef.current.value.length, inputRef.current.value.length)
     } else {
-      inputRef.current?.setSelectionRange(0, 0)
       inputRef.current?.blur()
     }
   }, [editing, inputRef])
 
   return (
     <div className='absolute left-0 right-0 mx-auto top-[30%] scale-95 -translate-y-[50%]'>
-      <div className="flex flex-col w-[80%] max-w-[480px] mx-auto z-10">
+      <form onSubmit={handleSubmit} className="flex flex-col w-[80%] max-w-[480px] mx-auto z-10">
         <Transition on className='absolute -top-[32px]'>
           <Text uppercase font="mono" size="3xs" className='text-slate-50'>Destination address</Text>
         </Transition>
@@ -64,33 +72,36 @@ const EditDestinationAddressForm = ({
             error={inputState.error}
             disabled={!editing}
           />
-          <Transition on className='absolute right-0 -bottom-12'>
-            {editing
-              ? (
+
+          {editing
+            ? (
+              <Transition on className='absolute right-0 top-[125%]'>
                 <Button
                   variant='primary'
-                  type='button'
+                  type='submit'
                   className='ml-auto py-[4px]'
-                  onClick={handleSave}
                   disabled={!inputState.isValid}
                 >
                   Save
                 </Button>
-              )
-              : (
+              </Transition>
+            )
+            : (
+              <Transition on className='absolute right-0 top-[130%]'>
                 <button
-                  type='button'
-                  className='py-1 px-2 flex items-center gap-2 text-white focus-visible:outline-slate-400'
+                  type='submit'
+                  className='py-[2px] flex items-center gap-2 text-white focus-visible:outline-slate-400'
                   onClick={() => setEditing(true)}
                 >
                   <EditIcon />
                   <Text size="xs" bold color='white'>Edit</Text>
                 </button>
-              )}
-          </Transition>
+              </Transition>
+            )}
+
         </div>
 
-      </div>
+      </form>
     </div>
   )
 }

--- a/renderer/src/pages/wallet/GridCanvas.tsx
+++ b/renderer/src/pages/wallet/GridCanvas.tsx
@@ -30,7 +30,7 @@ const GridCanvas = ({
   }
 
   useEffect(() => {
-    if (ref.current?.parentElement) {
+    if (ref.current?.parentElement && !grid.canvas?.isConnected) {
       grid.setCanvas({
         canvas: ref.current,
         container: ref.current.parentElement
@@ -44,17 +44,18 @@ const GridCanvas = ({
 
   useEffect(() => {
     if (!destinationFilAddress) {
-      return
+      grid.clear()
+      grid.renderGrid()
+    } else {
+      const config = getGridConfigForBalance(Number(walletBalance))
+      const isFirstRender = grid.force === 0
+      grid.updateWarp(config)
+      grid.tweenRender({
+        duration: 100,
+        targetForce: config.force,
+        delay: isFirstRender ? 500 : 0
+      })
     }
-
-    const config = getGridConfigForBalance(Number(walletBalance))
-    const isFirstRender = grid.force === 0
-    grid.updateWarp(config)
-    grid.tweenRender({
-      duration: 100,
-      targetForce: config.force,
-      delay: isFirstRender ? 500 : 0
-    })
   }, [destinationFilAddress, walletBalance])
 
   return (

--- a/renderer/src/pages/wallet/GridCanvas.tsx
+++ b/renderer/src/pages/wallet/GridCanvas.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { Wallet } from 'src/hooks/StationWallet'
 import { Grid, getGridConfigForBalance } from 'src/lib/grid'
 import { FILTransactionProcessing } from 'shared/typings'
@@ -19,15 +19,21 @@ const GridCanvas = ({
   const ref = useRef<HTMLCanvasElement>(null)
 
   // On resize, run setup again to correct positioning
-  function handleResize () {
+  const handleResize = useCallback(() => {
     if (!ref.current?.parentElement) return
 
     grid.setCanvas({
       canvas: ref.current,
       container: ref.current.parentElement
     })
-    grid.renderGrid()
-  }
+
+    if (!destinationFilAddress) {
+      grid.clear()
+      grid.renderGrid()
+    } else {
+      grid.renderAll()
+    }
+  }, [destinationFilAddress])
 
   useEffect(() => {
     if (ref.current?.parentElement && !grid.canvas?.isConnected) {
@@ -40,7 +46,7 @@ const GridCanvas = ({
     window.addEventListener('resize', handleResize)
 
     return () => window.removeEventListener('resize', handleResize)
-  }, [])
+  }, [handleResize])
 
   useEffect(() => {
     if (!destinationFilAddress) {

--- a/renderer/src/pages/wallet/TransactionHistory.tsx
+++ b/renderer/src/pages/wallet/TransactionHistory.tsx
@@ -36,7 +36,7 @@ const TransactionHistory = ({
   return (
     <Transition
       on={!!walletTransactions}
-      className='flex flex-col h-[300px] overflow-y-scroll custom-scrollbar'
+      className='absolute inset-0 top-2 flex flex-col h-[98%] overflow-y-scroll custom-scrollbar'
     >
       {completeTransactions && completeTransactions?.length > 0
         ? completeTransactions?.map((transaction) => (
@@ -80,8 +80,8 @@ const TransactionHistory = ({
           </button>
         ))
         : (
-          <div className='flex flex-col items-center text-center flex-1'>
-            <figure className='flex flex-1'>
+          <div className='flex flex-col items-center justify-center text-center flex-1'>
+            <figure className='flex mb-[5%]'>
               <img src={stationIllustration} alt='Station' className='m-auto' />
             </figure>
             <Text as="p" size='m' bold className='mb-1'>No transfers yet</Text>

--- a/renderer/src/pages/wallet/TransferWrapper.tsx
+++ b/renderer/src/pages/wallet/TransferWrapper.tsx
@@ -80,6 +80,7 @@ const TransferWrapper = ({
               walletBalance={walletBalance}
               sendThreshold={SEND_THRESHOLD}
               processingTransaction={processingTransaction}
+              destinationFilAddress={destinationFilAddress}
               transferAllFundsToDestinationWallet={transferAllFundsToDestinationWallet}
             />
           </Transition>

--- a/renderer/src/pages/wallet/TransferWrapper.tsx
+++ b/renderer/src/pages/wallet/TransferWrapper.tsx
@@ -35,7 +35,7 @@ const TransferWrapper = ({
 
   return (
     <section
-      className='w-1/2 bg-black relative flex flex-col overflow-hidden'
+      className='row-span-2 col-start-2 bg-black relative flex flex-col overflow-hidden'
       style={{ '--factor': 1 } as CSSProperties}
     >
       <GridCanvas

--- a/renderer/src/pages/wallet/Wallet.tsx
+++ b/renderer/src/pages/wallet/Wallet.tsx
@@ -49,8 +49,8 @@ const Wallet = () => {
                 &#47;&#47; Transaction history ... :
               </Text>
             </BorderedBox>
-            <BorderedBox className='flex flex-col gap-2 flex-1' isGrouped>
-              <TransactionHistory walletTransactions={walletTransactions} />
+            <BorderedBox className='flex flex-col gap-2 flex-1 relative' isGrouped>
+              <TransactionHistory walletTransactions={walletTransactions || []} />
             </BorderedBox>
           </div>
         </section>

--- a/renderer/src/pages/wallet/Wallet.tsx
+++ b/renderer/src/pages/wallet/Wallet.tsx
@@ -21,7 +21,7 @@ const Wallet = () => {
 
   return (
     <div className='w-full flex'>
-      <main className='px-9 mt-28 flex flex-col flex-1'>
+      <main className='px-9 mt-28 flex flex-col flex-1 animate-fadeIn'>
         <section className='flex flex-col gap-5 h-full mb-9'>
           <BorderedBox className='p-5 flex flex-col gap-2'>
             <Text font='mono' size='3xs' color='primary' uppercase>

--- a/renderer/src/pages/wallet/Wallet.tsx
+++ b/renderer/src/pages/wallet/Wallet.tsx
@@ -20,41 +20,30 @@ const Wallet = () => {
   } = useWallet()
 
   return (
-    <div className='w-full flex'>
-      <main className='px-9 mt-28 flex flex-col flex-1 animate-fadeIn'>
-        <section className='flex flex-col gap-5 h-full mb-9'>
-          <BorderedBox className='p-5 flex flex-col gap-2'>
-            <Text font='mono' size='3xs' color='primary' uppercase>
+    <div className='w-full grid grid-rows-[auto_1fr] grid-cols-[1fr_1fr]'>
+      <div className='px-9 mt-28 flex flex-col gap-5 animate-fadeIn'>
+        <BorderedBox className='p-5 flex flex-col gap-2'>
+          <Text font='mono' size='3xs' color='primary' uppercase>
               &#47;&#47; Station wallet balance ... :
-            </Text>
-            <Text font='mono' size='s'>{formatFilValue(walletBalance)}{' '}FIL</Text>
-          </BorderedBox>
-          <BorderedBox className='p-5 flex flex-col gap-2'>
-            <Text font='mono' size='3xs' color='primary' uppercase>&#47;&#47; Station address ... :</Text>
-            <div className='flex gap-5 items-center'>
-              <Address address={stationAddress} />
-              <Address address={stationAddress0x} />
-              <button
-                type='button'
-                className='text-primary ml-auto focus:outline-slate-400 w-5 h-5'
-                onClick={() => openExplorerLink(stationAddress)}
-              >
-                <LinkOut />
-              </button>
-            </div>
-          </BorderedBox>
-          <div className='flex-1 flex flex-col'>
-            <BorderedBox className='p-5 flex flex-col gap-2' isGrouped>
-              <Text font='mono' size='3xs' color='primary' uppercase>
-                &#47;&#47; Transaction history ... :
-              </Text>
-            </BorderedBox>
-            <BorderedBox className='flex flex-col gap-2 flex-1 relative' isGrouped>
-              <TransactionHistory walletTransactions={walletTransactions || []} />
-            </BorderedBox>
+          </Text>
+          <Text font='mono' size='s'>{formatFilValue(walletBalance)}{' '}FIL</Text>
+        </BorderedBox>
+        <BorderedBox className='p-5 flex flex-col gap-2'>
+          <Text font='mono' size='3xs' color='primary' uppercase>&#47;&#47; Station address ... :</Text>
+          <div className='flex gap-5 items-center'>
+            <Address address={stationAddress} />
+            <Address address={stationAddress0x} />
+            <button
+              type='button'
+              className='text-primary ml-auto focus:outline-slate-400 w-5 h-5'
+              onClick={() => openExplorerLink(stationAddress)}
+            >
+              <LinkOut />
+            </button>
           </div>
-        </section>
-      </main>
+        </BorderedBox>
+      </div>
+
       <TransferWrapper
         walletBalance={walletBalance}
         destinationFilAddress={destinationFilAddress}
@@ -63,6 +52,17 @@ const Wallet = () => {
         stationAddress={stationAddress}
         processingTransaction={processingTransaction}
       />
+
+      <div className='px-9 flex flex-col my-5'>
+        <BorderedBox className='p-5 flex flex-col gap-2' isGrouped tabIndex={2}>
+          <Text font='mono' size='3xs' color='primary' uppercase>
+                &#47;&#47; Transaction history ... :
+          </Text>
+        </BorderedBox>
+        <BorderedBox className='flex flex-col gap-2 flex-1 relative' isGrouped>
+          <TransactionHistory walletTransactions={walletTransactions || []} />
+        </BorderedBox>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
 - Some general styling fixes
 - For the "open at login" switch, the initial value is true. Change it to undefined, to not flash from true to false if the options is actually disabled.
 - Change element order in the wallet page, so when tabbing the focus goes to the transfer options before the tx history.
 - Fix copy in the "confirm transfer" step.
 - In the warped grid, ensure to render a flat grid when the destinationFIlAddress is not set