### PR TITLE
Add update historic rewards

### DIFF
--- a/renderer/src/hooks/StationRewards.tsx
+++ b/renderer/src/hooks/StationRewards.tsx
@@ -51,11 +51,18 @@ const useStationRewards = () => {
 
   useEffect(() => {
     async function loadStoredInfo () {
-      if (wallet.stationAddress0x) {
-        setHistoricalRewards(
-          await getHistoricalRewardsData(wallet.stationAddress0x)
-        )
-      }
+      if (!wallet.stationAddress0x) return
+      setHistoricalRewards(
+        await getHistoricalRewardsData(wallet.stationAddress0x)
+      )
+    }
+    loadStoredInfo()
+    const id = setInterval(loadStoredInfo, 60 * 60 * 1000)
+    return () => clearInterval(id)
+  }, [wallet.stationAddress0x])
+
+  useEffect(() => {
+    async function loadStoredInfo () {
       setScheduledRewards(await getScheduledRewards())
     }
     loadStoredInfo()

--- a/renderer/src/hooks/StationRewards.tsx
+++ b/renderer/src/hooks/StationRewards.tsx
@@ -51,7 +51,7 @@ const useStationRewards = () => {
 
   useEffect(() => {
     async function loadStoredInfo () {
-      if (!wallet.stationAddress0x) return
+      if (!wallet.stationAddress0x || document.hidden) return
       setHistoricalRewards(
         await getHistoricalRewardsData(wallet.stationAddress0x)
       )

--- a/renderer/src/hooks/StationRewards.tsx
+++ b/renderer/src/hooks/StationRewards.tsx
@@ -58,7 +58,11 @@ const useStationRewards = () => {
     }
     loadStoredInfo()
     const id = setInterval(loadStoredInfo, 60 * 60 * 1000)
-    return () => clearInterval(id)
+    document.addEventListener('visibilitychange', loadStoredInfo)
+    return () => {
+      clearInterval(id)
+      document.removeEventListener('visibilitychange', loadStoredInfo)
+    }
   }, [wallet.stationAddress0x])
 
   useEffect(() => {

--- a/renderer/src/hooks/StationRewards.tsx
+++ b/renderer/src/hooks/StationRewards.tsx
@@ -57,7 +57,7 @@ const useStationRewards = () => {
       )
     }
     loadStoredInfo()
-    const id = setInterval(loadStoredInfo, 60 * 60 * 1000)
+    const id = setInterval(loadStoredInfo, 20 * 60 * 1000)
     document.addEventListener('visibilitychange', loadStoredInfo)
     return () => {
       clearInterval(id)


### PR DESCRIPTION
Instead of only fetching historic rewards data when the app starts, refresh every 20 minutes (if the window is visible) or whenever the window becomes visible