### PR TITLE
Prevent error in convertEthTxHashToCid

### DIFF
--- a/main/wallet-backend.js
+++ b/main/wallet-backend.js
@@ -242,7 +242,7 @@ class WalletBackend {
         }
       )
       const body = /** @type {BeryxTransactionsResponse} */ (await res.json())
-      const tx = body.transactions.find(tx => tx.tx_type !== 'Fee')
+      const tx = body.transactions?.find(tx => tx.tx_type !== 'Fee')
       if (tx) {
         return tx.tx_cid
       }


### PR DESCRIPTION
Why:
 - After starting transactions, there are sometimes runtime errors because the beryx response doesn't have a transactions property yet. This causes the tx to be reported as failed on the UI

How:
 - Add an optional chaining in `convertEthTxHashToCid`