### PR TITLE
fix: rotate Sentry token

### DIFF
--- a/main/setup-sentry.js
+++ b/main/setup-sentry.js
@@ -8,7 +8,7 @@ const isDevBuild = BUILD_VERSION.endsWith('-dev')
 // Disable Sentry integration for dev builds
 if (!isDevBuild) {
   Sentry.init({
-    dsn: 'https://ff9615d8516545158e186d863a06a0f1@o1408530.ingest.sentry.io/6762462',
+    dsn: 'https://8667b1c7749ae24e35ba531bffa3ed7a@o1408530.ingest.us.sentry.io/6762462',
     release: BUILD_VERSION,
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.

--- a/renderer/src/components/Sentry.tsx
+++ b/renderer/src/components/Sentry.tsx
@@ -7,7 +7,7 @@ const SentryComponent = () => {
     if (window.electron.stationBuildVersion.endsWith('-dev')) { return }
 
     Sentry.init({
-      dsn: 'https://ff9615d8516545158e186d863a06a0f1@o1408530.ingest.sentry.io/6762462',
+      dsn: 'https://8667b1c7749ae24e35ba531bffa3ed7a@o1408530.ingest.us.sentry.io/6762462',
       integrations: [Sentry.browserTracingIntegration()],
       release: window.electron.stationBuildVersion,
       // Set tracesSampleRate to 1.0 to capture 100%


### PR DESCRIPTION
Old Station versions are producing too many un-actionable issues. We need to cut them off.

Related:
- #1606-
