### PR TITLE
deps: bump @filecoin-station/core from 21.1.0 to 21.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3648,9 +3648,9 @@
       }
     },
     "node_modules/@filecoin-station/core": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/@filecoin-station/core/-/core-21.1.0.tgz",
-      "integrity": "sha512-XYFlBwoZT3JbZP3R9ggAo6abMaNjNJ90pcz/YXOrhkNCitJ8rPpRdJbHmOm6Ca+bGnHEvSXCVJJfXTCf3SB+Cw==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/@filecoin-station/core/-/core-21.1.1.tgz",
+      "integrity": "sha512-R6yZ2PxA9JiubccjzM7I1JjtFfzOmdrvDcFlW8sGrx6rGe4jOXZi7+vjZ6QQJygLykoxaXUaznra/WhakM5oPQ==",
       "hasInstallScript": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/filecoin-station/desktop#readme",
   "dependencies": {
-    "@filecoin-station/core": "^21.1.0",
+    "@filecoin-station/core": "^21.1.1",
     "@filecoin-station/spark-impact-evaluator": "^1.1.1",
     "@glif/filecoin-address": "3.0.7",
     "@glif/filecoin-message": "^3.0.5",


### PR DESCRIPTION
Bump [@filecoin-station/core](https://github.com/filecoin-station/core) from 21.1.0 to 21.1.1.
- [Release notes](https://github.com/filecoin-station/core/releases/v21.1.1)
- [Commits](https://github.com/filecoin-station/core/compare/v21.1.0...v21.1.1)
