### PR TITLE
fix: tooltip about scheduled rewards

### DIFF
--- a/renderer/src/pages/dashboard/RewardsInfo.tsx
+++ b/renderer/src/pages/dashboard/RewardsInfo.tsx
@@ -38,8 +38,8 @@ const RewardsInfo = ({
                 <i><InfoIcon className='text-primary relative -top-3' /></i>
               }
               style={{ maxWidth: '230px' }}
-              content={`This is the reward total you have accrued since your last payout. 
-              Scheduled earning will be sent to your Station Wallet approximately once a month, 
+              content={`This is the reward total you have accrued since your last payout.
+              Scheduled earning will be sent to your Station Wallet approximately once a week,
               provided you have earned more than the payout threshold.`}
             />
 


### PR DESCRIPTION
We are paying them out every week, not every month.

Before my change:

<img width="350" alt="Screenshot 2024-07-11 at 16 28 59" src="https://github.com/filecoin-station/desktop/assets/1140553/3a5d0915-13ff-4776-b993-57ebcc37fd1f">
