### PR TITLE
Add no data screen

### DIFF
--- a/renderer/src/pages/dashboard/Chart.tsx
+++ b/renderer/src/pages/dashboard/Chart.tsx
@@ -21,7 +21,8 @@ import {
   updateTooltipElement,
   renderPayoutEvents,
   getTooltipValues,
-  chartPadding
+  chartPadding,
+  timeRangeDesc
 } from './chart-utils'
 import ChartTooltip from './ChartTooltip'
 import FilecoinSymbol from 'src/assets/img/icons/filecoin.svg'
@@ -55,6 +56,8 @@ const Chart = ({
   const [aspectRatio, setAspectRatio] = useState<number>()
   const containerRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
+
+  const hasDataInRange = historicalRewards.length > 0
 
   const chartData = useMemo(() =>
     historicalRewards.reduce<{
@@ -108,6 +111,13 @@ const Chart = ({
 
   return (
     <div ref={containerRef} className='relative flex-1 max-w-full flex items-center'>
+      {!hasDataInRange && (
+        <div className='absolute inset-0 mb-6 flex items-center justify-center'>
+          <p className='text-slate-400 text-sm'>
+            It seems you have no rewards accrued in the {timeRangeDesc[timeRange]}
+          </p>
+        </div>
+      )}
       <ChartTooltip ref={tooltipRef} />
       <img data-filecoinsymbol className='absolute opacity-0' src={FilecoinSymbol} alt="Filecoin symbol" />
       {aspectRatio
@@ -157,7 +167,7 @@ const Chart = ({
                   grid: {
                     color: colors.xLine,
                     drawTicks: false,
-                    drawOnChartArea: true
+                    drawOnChartArea: hasDataInRange
                   },
                   min: 0
                 },

--- a/renderer/src/pages/dashboard/Chart.tsx
+++ b/renderer/src/pages/dashboard/Chart.tsx
@@ -21,8 +21,7 @@ import {
   updateTooltipElement,
   renderPayoutEvents,
   getTooltipValues,
-  chartPadding,
-  timeRangeDataWarning
+  chartPadding
 } from './chart-utils'
 import ChartTooltip from './ChartTooltip'
 import FilecoinSymbol from 'src/assets/img/icons/filecoin.svg'
@@ -114,7 +113,7 @@ const Chart = ({
       {!hasDataInRange && (
         <div className='absolute inset-0 mb-6 flex items-center justify-center'>
           <p className='text-slate-400 text-sm'>
-            {timeRangeDataWarning(timeRange)}
+            It seems you have no rewards accrued in the selected period
           </p>
         </div>
       )}

--- a/renderer/src/pages/dashboard/Chart.tsx
+++ b/renderer/src/pages/dashboard/Chart.tsx
@@ -22,7 +22,7 @@ import {
   renderPayoutEvents,
   getTooltipValues,
   chartPadding,
-  timeRangeDesc
+  timeRangeDataWarning
 } from './chart-utils'
 import ChartTooltip from './ChartTooltip'
 import FilecoinSymbol from 'src/assets/img/icons/filecoin.svg'
@@ -114,7 +114,7 @@ const Chart = ({
       {!hasDataInRange && (
         <div className='absolute inset-0 mb-6 flex items-center justify-center'>
           <p className='text-slate-400 text-sm'>
-            It seems you have no rewards accrued in the {timeRangeDesc[timeRange]}
+            {timeRangeDataWarning(timeRange)}
           </p>
         </div>
       )}

--- a/renderer/src/pages/dashboard/Chart.tsx
+++ b/renderer/src/pages/dashboard/Chart.tsx
@@ -113,7 +113,7 @@ const Chart = ({
       {!hasDataInRange && (
         <div className='absolute inset-0 mb-6 flex items-center justify-center'>
           <p className='text-slate-400 text-sm'>
-            It seems you have no rewards accrued in the selected period
+            You have accrued no rewards in the selected period
           </p>
         </div>
       )}

--- a/renderer/src/pages/dashboard/chart-utils.ts
+++ b/renderer/src/pages/dashboard/chart-utils.ts
@@ -221,9 +221,13 @@ export const renderPayoutEvents: CustomPlugin = {
 
 }
 
-export const timeRangeDesc: Record<TimeRange, string> = {
-  '7d': 'past 7 days',
-  '1m': 'past month',
-  '1y': 'past year',
-  all: ''
+export const timeRangeDataWarning = (timeRange: TimeRange) => {
+  const ranges = {
+    '7d': 'in the past 7 days',
+    '1m': 'in the past month',
+    '1y': 'in the past year',
+    all: 'yet'
+  }
+
+  return `It seems you have no rewards accrued ${ranges[timeRange]}`
 }

--- a/renderer/src/pages/dashboard/chart-utils.ts
+++ b/renderer/src/pages/dashboard/chart-utils.ts
@@ -220,3 +220,10 @@ export const renderPayoutEvents: CustomPlugin = {
   }
 
 }
+
+export const timeRangeDesc: Record<TimeRange, string> = {
+  '7d': 'past 7 days',
+  '1m': 'past month',
+  '1y': 'past year',
+  all: ''
+}

--- a/renderer/src/pages/dashboard/chart-utils.ts
+++ b/renderer/src/pages/dashboard/chart-utils.ts
@@ -218,16 +218,4 @@ export const renderPayoutEvents: CustomPlugin = {
       }
     }
   }
-
-}
-
-export const timeRangeDataWarning = (timeRange: TimeRange) => {
-  const ranges = {
-    '7d': 'in the past 7 days',
-    '1m': 'in the past month',
-    '1y': 'in the past year',
-    all: 'yet'
-  }
-
-  return `It seems you have no rewards accrued ${ranges[timeRange]}`
 }


### PR DESCRIPTION
Fixes #1679 

 - Add a warning when there are no records in the selected time range. Display "It seems you have no rewards accrued in the past 7 days | past month | past year | yet"
 - Is there better copy for this?

<img width="1320" alt="Screenshot 2024-07-17 at 13 51 35" src="https://github.com/user-attachments/assets/0cfd5cfc-0431-4b6a-a8ea-693ec21c7439">
