### PR TITLE
Adjust balance font-size

### DIFF
--- a/renderer/src/pages/wallet/BalanceControl.tsx
+++ b/renderer/src/pages/wallet/BalanceControl.tsx
@@ -6,6 +6,7 @@ import Tooltip from 'src/components/Tooltip'
 import { ReactNode, useState } from 'react'
 import Transition from 'src/components/Transition'
 import TransactionStatusIndicator from 'src/components/TransactionStatusIndicator'
+import classNames from 'classnames'
 
 const TooltipWrapper = ({ children, hasTooltip }: {children: ReactNode; hasTooltip: boolean}) => {
   if (!hasTooltip) return children
@@ -90,7 +91,14 @@ const BalanceControl = ({
           className='m-auto flex flex-col gap-5 items-center justify-center h-full'
         >
           <div className='flex flex-col justify-end h-[55%]'>
-            <Text font="mono" size="xl" bold className="text-slate-50">
+            <Text
+              font="mono"
+              size="xl"
+              bold
+              className={classNames('text-slate-50 text-center',
+                formatFilValue(walletBalance).length > 8 ? 'text-[1.85rem]' : 'text-[2rem]'
+              )}
+            >
               {formatFilValue(walletBalance)} FIL
             </Text>
           </div>


### PR DESCRIPTION
Adjust font-size in wallet page balance display to account for more decimals.

<img width="485" alt="Screenshot 2024-07-17 at 14 16 27" src="https://github.com/user-attachments/assets/8b6e9809-1be3-4c52-9e7c-3da86e9a282b">
<img width="513" alt="Screenshot 2024-07-17 at 14 16 01" src="https://github.com/user-attachments/assets/23abf17b-fc36-49e3-a3f8-ebbb116ed20d">
