### PR TITLE
Chart: fix scheduled rewards on and after a payout

### DIFF
--- a/renderer/src/pages/dashboard/Chart.tsx
+++ b/renderer/src/pages/dashboard/Chart.tsx
@@ -64,11 +64,17 @@ const Chart = ({
       totalRewards: number[];
       scheduled: number[];
     }>(
-      (acc, record) => {
+      (acc, record, index) => {
         acc.labels.push(new Date(record.timestamp).getTime())
         acc.totalRewards.push(getRewardValue(record.totalRewardsReceived, moduleId))
-        acc.scheduled.push(getRewardValue(record.totalScheduledRewards, moduleId))
-
+        const isPayout = index > 0 && getRewardValue(record.totalRewardsReceived, moduleId) >
+          getRewardValue(historicalRewards[index - 1].totalRewardsReceived, moduleId)
+        acc.scheduled.push(
+          isPayout
+            ? getRewardValue(record.totalScheduledRewards, moduleId)
+            : getRewardValue(record.totalScheduledRewards, moduleId) +
+              getRewardValue(record.totalRewardsReceived, moduleId)
+        )
         return acc
       }, {
         labels: [],
@@ -76,6 +82,7 @@ const Chart = ({
         scheduled: []
       })
   , [historicalRewards, moduleId])
+  console.log(chartData)
 
   const onTooltipUpdate = useCallback<ExternalToltipHandler>((args) => {
     if (!tooltipRef.current) {

--- a/renderer/src/pages/dashboard/chart-utils.ts
+++ b/renderer/src/pages/dashboard/chart-utils.ts
@@ -149,7 +149,7 @@ export function updateTooltipElement ({
     element.querySelector('[data-scheduled]')?.replaceChildren(
       isPayout
         ? `${formatFilValue(payoutValue.toString())} FIL`
-        : `${formatFilValue(scheduled.toString())} FIL`
+        : `${formatFilValue((scheduled - totalReceived).toString())} FIL`
     )
     content.setAttribute('data-ispayout', isPayout ? 'true' : 'false')
     content.style.transform = `translate(${position.x}px, ${position.y}px)`


### PR DESCRIPTION
Before:

![Screenshot 2024-07-29 at 23 09 56](https://github.com/user-attachments/assets/71a4e1f1-9ab4-40c5-b005-482419f43eb9)

After:

![Screenshot 2024-07-29 at 23 22 34](https://github.com/user-attachments/assets/f36c241a-ef9b-4472-a9e2-8b32a23bad22)
