### PR TITLE
fix: typings import from Station Core

### DIFF
--- a/shared/typings.ts
+++ b/shared/typings.ts
@@ -1,4 +1,4 @@
-import { ActivityEvent } from '@filecoin-station/core'
+import { ActivityEvent } from '@filecoin-station/core/dist/lib/activity'
 
 export type FILTransactionStatus = 'succeeded' | 'processing' | 'failed'
 


### PR DESCRIPTION
This is a stop-gap solution to fix the CI.

I opened a GH issue in Station Core describing a more robust solution: 
- https://github.com/filecoin-station/core/issues/612