### PR TITLE
formattedFilToBigInt: fix float to bigint error due to lack of precision

### DIFF
--- a/renderer/src/lib/utils.ts
+++ b/renderer/src/lib/utils.ts
@@ -15,7 +15,7 @@ export function formatFilValue (value = '') {
 }
 
 export function formattedFilToBigInt (value: string) {
-  return BigInt(Number(value) * 1e18)
+  return BigInt(Math.floor(Number(value) * 1e18))
 }
 
 export function bigIntFilToNumber (value: bigint) {


### PR DESCRIPTION
Fixes:

<img width="547" alt="Screenshot 2024-12-02 at 17 34 36" src="https://github.com/user-attachments/assets/96fd42c1-cdd6-4eba-8b6f-11368b8acc5d">

This .0005 comes from multiplying by 1e18

The impact of this error is that scheduled rewards get shown as 0, therefore I'm going to merge and release before review.